### PR TITLE
Ignore Claude Code local settings to preserve user autonomy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,10 @@ cython_debug/
 #   Learn more at https://abstra.io/docs
 .abstra/
 
+# Claude Code
+#   Local user-specific permissions and settings
+.claude/settings.local.json
+
 # Visual Studio Code
 #   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
 #   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore


### PR DESCRIPTION
## Summary

Adds `.claude/settings.local.json` to `.gitignore` to allow users to maintain their own Claude Code permission preferences without team-wide enforcement.

## Rationale

Unlike `.vscode/settings.json` (which defines shared development environment), Claude Code permissions in `settings.local.json` are user-specific preferences that should not be imposed across the team. Each developer should have autonomy over which Claude Code commands they want to pre-approve.

## Changes

- Added `.claude/settings.local.json` to `.gitignore`
- Added documentation comment explaining the rationale

🤖 Generated with [Claude Code](https://claude.com/claude-code)