### PR TITLE
Add .venv verification step to PR finalization process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,8 +134,9 @@ Finalize PR?
 **What "Finalize" means** (unless user specifies otherwise):
 1. Merge PR with squash merge and delete remote branch
 2. Update local develop branch (checkout and pull)
-3. Run final validation (tests, coverage, quality checks)
-4. Ready for next iteration of changes
+3. Verify .venv is in sync with dependency specification (poetry install --sync)
+4. Run final validation (tests, coverage, quality checks)
+5. Ready for next iteration of changes
 
 **What this checkpoint gives the user:**
 - Time to review the PR on GitHub
@@ -151,7 +152,7 @@ Finalize PR?
 3. ⏸️ **PAUSE #1** - Ask: "Create PR?"
 4. If approved: Push branch and create PR
 5. ⏸️ **PAUSE #2** - Ask: "Finalize PR?"
-6. If approved: Execute three-step finalization (merge, update develop, validate)
+6. If approved: Execute four-step finalization (merge, update develop, verify .venv, validate)
 7. If not approved: Wait for user to review/request changes
 
 ## Project Structure


### PR DESCRIPTION
## Summary

Updated PR finalization workflow to include explicit .venv verification before running tests, addressing past issues where unhealthy virtual environments caused test failures.

## Changes

- **Added Step 3 to finalization process**: "Verify Virtual Environment is Clean"
  - Uses `poetry install --sync` to ensure .venv matches lock file exactly
  - Runs AFTER updating develop branch but BEFORE running tests
- **Renamed process**: "Three-Step" → "Four-Step Finalization Process"
- **Updated documentation**: Both CLAUDE.md and docs/standards-and-conventions.md
- **Updated workflow examples**: Complete workflow, common mistakes section
- **Adjusted time estimate**: 30 seconds → 45 seconds

## Rationale

While the test suite should catch .venv health issues, running verification BEFORE tests prevents unnecessary test failures and makes debugging clearer when tests do fail. This addresses past experiences where stale dependencies caused tests to "implode."

## Test Plan

- [x] Documentation changes only - no code changes
- [x] Verified markdown formatting is correct
- [x] All workflow examples updated consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)