### PR TITLE
Fix poetry sync command and add heredoc failure warning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,48 @@ gh pr create --base develop --title "..." --body "..."
 
 **If you forget**: You'll need to move commits from develop to a feature branch before pushing. Don't let this happen.
 
+## CRITICAL: Heredoc Commands ALWAYS FAIL - Use Temp Files Instead
+
+**⚠️ ATTENTION CLAUDE: This is a recurring failure pattern that happens EVERY session.**
+
+When creating git commits or GitHub PRs with multi-line messages, **HEREDOC syntax ALWAYS FAILS** in this environment. You repeatedly try commands like:
+
+```bash
+# ❌ THIS ALWAYS FAILS - DO NOT USE
+git commit -m "$(cat <<'EOF'
+Multi-line commit message
+EOF
+)"
+
+gh pr create --body "$(cat <<'EOF'
+Multi-line PR body
+EOF
+)"
+```
+
+**✅ CORRECT APPROACH: Use a temporary file**
+
+```bash
+# Create temp file with content
+cat > /tmp/commit-msg.txt << 'EOF'
+Multi-line commit message
+EOF
+
+# Use the temp file
+git commit -F /tmp/commit-msg.txt
+rm /tmp/commit-msg.txt
+
+# For PR creation
+cat > /tmp/pr-body.txt << 'EOF'
+Multi-line PR body
+EOF
+
+gh pr create --base develop --title "..." --body-file /tmp/pr-body.txt
+rm /tmp/pr-body.txt
+```
+
+**Why this matters**: Every session you attempt heredocs, they fail, and you have to debug and retry. This wastes time. **USE TEMP FILES FROM THE START.**
+
 ## Before You Act: Consult Documentation First
 
 **CRITICAL**: This project follows a documentation-first methodology. All knowledge required for any AI agent to work effectively is present in the repository. **Always read the relevant documentation BEFORE taking action** - never rely on trial-and-error.
@@ -134,7 +176,7 @@ Finalize PR?
 **What "Finalize" means** (unless user specifies otherwise):
 1. Merge PR with squash merge and delete remote branch
 2. Update local develop branch (checkout and pull)
-3. Verify .venv is in sync with dependency specification (poetry install --sync)
+3. Verify .venv is in sync with dependency specification (poetry sync)
 4. Run final validation (tests, coverage, quality checks)
 5. Ready for next iteration of changes
 

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -496,7 +496,7 @@ git status
 ```bash
 # CRITICAL: Sync .venv with dependency specification
 # This prevents test failures from stale or conflicting dependencies
-poetry install --sync
+poetry sync
 
 # Expected output: "Installing dependencies from lock file"
 # If dependencies are already synced: "No dependencies to install or update"
@@ -558,7 +558,7 @@ gh pr create --title "Add user authentication" --body "..." --base develop
 gh pr merge <PR#> --squash --delete-branch
 git checkout develop
 # Verify .venv is clean
-poetry install --sync
+poetry sync
 # Run final validation
 poetry run pytest --cov=mnemosys_core --cov-report=term-missing --cov-branch
 poetry run ruff check && poetry run mypy src/
@@ -604,7 +604,7 @@ git checkout develop
 gh pr merge 14 --squash --delete-branch
 git checkout develop
 # Verify .venv is clean first!
-poetry install --sync
+poetry sync
 # Then run full validation!
 poetry run pytest --cov=mnemosys_core --cov-report=term-missing --cov-branch
 poetry run ruff check && poetry run mypy src/


### PR DESCRIPTION
## Summary

Fixed two documentation issues discovered after PR #19:

1. **Corrected Poetry command**: Poetry deprecated `poetry install --sync` in favor of `poetry sync`
2. **Added heredoc failure warning**: Documented recurring issue where heredoc syntax always fails for multi-line git/PR messages

## Changes

### Poetry Command Update
- **CLAUDE.md**: Updated finalization step 3 to use `poetry sync`
- **docs/standards-and-conventions.md**: Updated all 3 instances:
  - Step 3 of finalization process
  - Complete workflow example
  - Common mistakes section

### Heredoc Warning
- **CLAUDE.md**: Added new section "CRITICAL: Heredoc Commands ALWAYS FAIL - Use Temp Files Instead"
- Placed prominently at top of file for maximum visibility
- Includes failing pattern examples and correct temp file approach
- Prevents time-wasting debugging that occurs every session

## Test Plan

- [x] Documentation changes only - no code changes
- [x] Verified markdown formatting is correct
- [x] Tested temp file approach for this PR (used it to create this PR!)
- [x] All instances of deprecated command updated

## Rationale

Poetry's deprecation warning appeared during PR #19 finalization. The heredoc issue is a recurring pattern that wastes time in every session - documenting it prominently should prevent future failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
