### PR TITLE
docs: remove fragile line number references from coverage exception docs

### DIFF
--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -271,9 +271,9 @@ def handle_database_connection(config: dict) -> Connection:
     """
     Establish database connection with retry logic.
 
-    Note: The connection timeout branch (lines 45-48) cannot be reliably
-    tested in unit tests due to non-deterministic timing behavior.
-    Integration tests cover this scenario.
+    Note: The connection timeout branch cannot be reliably tested in unit
+    tests due to non-deterministic timing behavior. Integration tests
+    cover this scenario.
     """
     try:
         return connect(config)
@@ -303,6 +303,8 @@ def handle_database_connection(config: dict) -> Connection:
 ```python
 # pragma: no cover - <brief reason>, <where it IS tested if applicable>
 ```
+
+**IMPORTANT**: Do not include specific line numbers in docstrings or comments explaining coverage exceptions. Line numbers become stale as code evolves, and developers rarely remember to update them. Instead, describe the code path or branch conceptually (e.g., "the connection timeout branch" rather than "lines 45-48").
 
 #### Coverage Reporting
 


### PR DESCRIPTION
## Summary

Fixes fragile line number references in coverage exception documentation that become stale as code evolves.

**Changes:**
- Removed line number reference ("lines 45-48") from docstring example
- Added explicit guidance warning against using line numbers in coverage exception docs
- Recommends describing code paths conceptually (e.g., "the connection timeout branch" vs "lines 45-48")

## Rationale

Line numbers in docstrings and comments become stale when code changes, and developers rarely remember to update them. This creates misleading documentation that references non-existent or incorrect line numbers.

## Test Plan

- ✅ All 166 tests passing
- ✅ Ruff: All checks passed
- ✅ Mypy: Success, no issues found
- ✅ Documentation-only change, no code modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)
