### PR TITLE
Add coverage configuration to standardize coverage measurement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,3 +114,7 @@ filterwarnings = [
     "ignore:unclosed database:ResourceWarning",
     "ignore::ResourceWarning",
 ]
+
+[tool.coverage.run]
+source = ["src/mnemosys_core"]
+branch = true


### PR DESCRIPTION
## Summary

Adds coverage configuration to `pyproject.toml` to ensure consistent coverage measurement across all tools (VSCode, CLI, CI/CD).

**Problem:** VSCode's "Run tests with coverage" defaulted to `--cov=.` (measuring all files including tests), showing 99% coverage. CLI validation used `--cov=mnemosys_core` (measuring source only), showing 100%.

**Solution:** Add `[tool.coverage.run]` section specifying `source = ["src/mnemosys_core"]` and `branch = true`. Now all tools use the same configuration automatically.

**Impact:** VSCode coverage UI will now show 100% matching CLI/CI results.

## Test plan

- [x] Verified coverage runs correctly with new config (`pytest --cov` shows 100%)
- [x] All existing tests pass (166/166)
- [x] Configuration follows pytest-cov best practices

🤖 Generated with [Claude Code](https://claude.com/claude-code)
