### PR TITLE
docs: add git remote prune to PR finalization process

### DIFF
--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -515,6 +515,9 @@ poetry sync
 # Delete local feature branch (if not already deleted)
 git branch -d <branch-name>
 
+# Clean up stale remote branch references
+git remote prune origin
+
 # Run FINAL validation on target branch
 poetry run pytest --cov=mnemosys_core --cov-report=term-missing --cov-branch
 poetry run ruff check
@@ -526,6 +529,11 @@ poetry run mypy src/
 # ✅ Ruff: All checks passed
 # ✅ Mypy: Success, no issues found
 ```
+
+**Why prune remote references?**
+- Removes stale tracking references to deleted remote branches
+- Prevents confusion when listing branches (e.g., `git branch -a`)
+- Keeps local repository metadata clean and accurate
 
 **Why final validation?**
 - Confirms merge was successful
@@ -561,6 +569,8 @@ gh pr merge <PR#> --squash --delete-branch
 git checkout develop
 # Verify .venv is clean
 poetry sync
+# Clean up stale remote references
+git remote prune origin
 # Run final validation
 poetry run pytest --cov=mnemosys_core --cov-report=term-missing --cov-branch
 poetry run ruff check && poetry run mypy src/


### PR DESCRIPTION
## Summary

Updates PR finalization documentation to include `git remote prune origin` as part of the cleanup process.

**Problem:** After merging PRs with `gh pr merge --squash --delete-branch`, Git maintains stale tracking references to deleted remote branches. Running `git branch -a` shows `remotes/origin/<branch>` entries that no longer exist on the remote, causing confusion.

**Solution:** Add `git remote prune origin` to Step 4 of the PR finalization process. This command removes stale remote-tracking references, keeping local repository metadata accurate.

**Changes:**
- Added prune command to Step 4 of finalization process
- Added prune command to complete workflow example
- Added "Why prune remote references?" explanation section

## Test plan

- [x] Documentation changes only, no code changes
- [x] Verified command works correctly (tested during PR #22 finalization)
- [x] Formatting and structure consistent with existing docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
