### PR TITLE
Fix VSCode coverage to respect pyproject.toml source configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,8 @@
   "python.testing.nosetestsEnabled": false,
   "python.testing.pytestPath": ".venv/bin/pytest",
   "python.testing.pytestArgs": [
-    "tests"
+    "tests",
+    "--cov"
   ],
   "python.analysis.extraPaths": [
     "src"


### PR DESCRIPTION
## Summary

Fixes VSCode Test Explorer to respect the `[tool.coverage.run]` source configuration in pyproject.toml by adding `--cov` flag to `pytestArgs`.

## Root Cause

VSCode Python extension automatically adds `--cov=.` when no coverage argument is present in `pytestArgs`. This `--cov=<path>` syntax causes pytest-cov to override the `[tool.coverage.run]` source configuration in pyproject.toml, measuring coverage at workspace root (`.`) instead of only `src/mnemosys_core`.

## Solution

Added `--cov` (without a value) to `.vscode/settings.json` `pytestArgs`:
- Prevents VSCode from auto-injecting `--cov=.`
- Allows pytest-cov to respect pyproject.toml source configuration
- Coverage now correctly measures only `src/mnemosys_core`

## References

- [VSCode Python Testing Documentation](https://code.visualstudio.com/docs/python/testing)
- [pytest-cov Configuration](https://pytest-cov.readthedocs.io/en/latest/config.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
