### PR TITLE
Hotfix: Fix NameError in Exercise model

### DIFF
--- a/src/mnemosys_core/db/models/exercise.py
+++ b/src/mnemosys_core/db/models/exercise.py
@@ -53,7 +53,7 @@ class Exercise(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     name: Mapped[str] = mapped_column(String(200), nullable=False, unique=True)
-    domains: Mapped[list[str]] = mapped_column(EncodedList, nullable=False)
+    domains: Mapped[list[str]] = mapped_column(JSONEncodedList, nullable=False)
     # Note: technique_tags removed - replaced with relationship below
     # Note: supported_overload_dimensions removed - replaced with relationship below
     instrument_compatibility: Mapped[list[str] | None] = mapped_column(JSONEncodedList, nullable=True)


### PR DESCRIPTION
Fix typo introduced in PR #26 where `EncodedList` was used instead of `JSONEncodedList`.

This broke all tests with:
```
NameError: name 'EncodedList' is not defined
```

Tests now pass (verified before creating PR).