### PR TITLE
refactor: remove module-level db session factory

### DIFF
--- a/tests/api/test_dependencies.py
+++ b/tests/api/test_dependencies.py
@@ -3,23 +3,17 @@ Dependency injection tests.
 """
 
 import pytest
+from fastapi import FastAPI, Request
 
 from mnemosys_core.api.dependencies import get_db
 
 
 def test_get_db_without_configuration() -> None:
     """Test that get_db raises error when not configured."""
-    # Reset the global session factory to None
-    import mnemosys_core.api.dependencies as deps
+    app = FastAPI()
+    scope = {"type": "http", "app": app, "headers": []}
+    request = Request(scope)
 
-    original_factory = deps._session_factory
-    deps._session_factory = None
-
-    try:
-        # Attempt to get a database session
-        with pytest.raises(RuntimeError, match="Dependencies not configured"):
-            generator = get_db()
-            next(generator)
-    finally:
-        # Restore original factory
-        deps._session_factory = original_factory
+    with pytest.raises(RuntimeError, match="Dependencies not configured"):
+        generator = get_db(request)
+        next(generator)


### PR DESCRIPTION
## Summary
- Move session factory storage to FastAPI app.state (no module-level global).
- Update get_db to read from Request.app.state and adjust dependency test.

## Testing
- python3 scripts/dev/validate_local.py
