### PR TITLE
Dispose test engines to avoid ResourceWarnings

### DIFF
--- a/tests/db/test_exercise_instance.py
+++ b/tests/db/test_exercise_instance.py
@@ -52,6 +52,7 @@ def test_exercise_instance_creation() -> None:
     assert retrieved.exercise.name == "Chromatic Scale"
     assert retrieved.practice.total_minutes == 60
     session_db.close()
+    engine.dispose()
 
 
 def test_exercise_instance_parameters_optional() -> None:
@@ -83,6 +84,7 @@ def test_exercise_instance_parameters_optional() -> None:
     assert retrieved is not None
     assert retrieved.parameters == {}
     session_db.close()
+    engine.dispose()
 
 
 def test_session_has_multiple_exercise_instances() -> None:
@@ -133,6 +135,7 @@ def test_session_has_multiple_exercise_instances() -> None:
     assert retrieved_session.exercise_instances[1].sequence_order == 2
     assert retrieved_session.exercise_instances[2].sequence_order == 3
     session_db.close()
+    engine.dispose()
 
 
 def test_exercise_instance_repr() -> None:
@@ -162,3 +165,4 @@ def test_exercise_instance_repr() -> None:
     assert "ExerciseInstance" in repr(instance)
     assert "5" in repr(instance)
     session_db.close()
+    engine.dispose()

--- a/tests/db/test_exercise_log.py
+++ b/tests/db/test_exercise_log.py
@@ -55,6 +55,7 @@ def test_exercise_log_creation() -> None:
     assert retrieved.notes == "Great session!"
     assert retrieved.exercise_instance.sequence_order == 1
     session_db.close()
+    engine.dispose()
 
 
 def test_exercise_log_notes_optional() -> None:
@@ -92,6 +93,7 @@ def test_exercise_log_notes_optional() -> None:
     assert retrieved is not None
     assert retrieved.notes is None
     session_db.close()
+    engine.dispose()
 
 
 def test_exercise_instance_has_log() -> None:
@@ -131,6 +133,7 @@ def test_exercise_instance_has_log() -> None:
     assert retrieved_instance.log is not None
     assert retrieved_instance.log.completion_status == CompletionStatus.YES
     session_db.close()
+    engine.dispose()
 
 
 def test_exercise_log_repr() -> None:
@@ -167,3 +170,4 @@ def test_exercise_log_repr() -> None:
     assert "yes" in repr(log)
     assert "clean" in repr(log)
     session_db.close()
+    engine.dispose()

--- a/tests/db/test_exercise_overload_dimension_relationship.py
+++ b/tests/db/test_exercise_overload_dimension_relationship.py
@@ -31,6 +31,7 @@ def test_exercise_can_support_multiple_overload_dimensions() -> None:
     assert len(retrieved.overload_dimensions) == 3
     assert any(od.name == "tempo" for od in retrieved.overload_dimensions)
     session.close()
+    engine.dispose()
 
 
 def test_overload_dimension_can_be_used_by_multiple_exercises() -> None:
@@ -57,3 +58,4 @@ def test_overload_dimension_can_be_used_by_multiple_exercises() -> None:
     assert retrieved_dimension is not None
     assert len(retrieved_dimension.exercises) == 2
     session.close()
+    engine.dispose()

--- a/tests/db/test_exercise_state_relationship.py
+++ b/tests/db/test_exercise_state_relationship.py
@@ -26,6 +26,7 @@ def test_exercise_has_one_exercise_state() -> None:
     assert retrieved_exercise.exercise_state is not None  # Should be singular, not plural
     assert retrieved_exercise.exercise_state.exercise_id == exercise.id
     session.close()
+    engine.dispose()
 
 
 def test_exercise_state_unique_per_exercise() -> None:
@@ -56,6 +57,7 @@ def test_exercise_state_unique_per_exercise() -> None:
         session.rollback()
     finally:
         session.close()
+        engine.dispose()
 
 
 def test_exercise_without_state() -> None:
@@ -73,3 +75,4 @@ def test_exercise_without_state() -> None:
     assert retrieved is not None
     assert retrieved.exercise_state is None  # No state yet
     session.close()
+    engine.dispose()

--- a/tests/db/test_exercise_technique_relationship.py
+++ b/tests/db/test_exercise_technique_relationship.py
@@ -31,6 +31,7 @@ def test_exercise_can_use_multiple_techniques() -> None:
     assert len(retrieved.techniques) == 3
     assert any(t.name == "alternate picking" for t in retrieved.techniques)
     session.close()
+    engine.dispose()
 
 
 def test_technique_can_be_used_by_multiple_exercises() -> None:
@@ -57,3 +58,4 @@ def test_technique_can_be_used_by_multiple_exercises() -> None:
     assert retrieved_technique is not None
     assert len(retrieved_technique.exercises) == 2
     session.close()
+    engine.dispose()

--- a/tests/db/test_instrument_polymorphism.py
+++ b/tests/db/test_instrument_polymorphism.py
@@ -30,6 +30,7 @@ def test_base_instrument_has_discriminator() -> None:
     # Verify discriminator is set
     assert instrument.instrument_type == "stringed"
     session.close()
+    engine.dispose()
 
 
 def test_stringed_instrument_creation() -> None:
@@ -52,6 +53,7 @@ def test_stringed_instrument_creation() -> None:
     assert retrieved.scale_length == 34.0
     assert retrieved.instrument_type == "stringed"
     session.close()
+    engine.dispose()
 
 
 def test_placeholder_instruments_exist() -> None:
@@ -72,6 +74,7 @@ def test_placeholder_instruments_exist() -> None:
     assert session.query(WindInstrument).count() == 1
     assert session.query(PercussionInstrument).count() == 1
     session.close()
+    engine.dispose()
 
 
 def test_polymorphic_query_returns_correct_types() -> None:
@@ -95,6 +98,7 @@ def test_polymorphic_query_returns_correct_types() -> None:
     assert isinstance(instruments[0], StringedInstrument)
     assert isinstance(instruments[1], KeyboardInstrument)
     session.close()
+    engine.dispose()
 
 
 def test_base_instrument_repr() -> None:
@@ -117,6 +121,7 @@ def test_base_instrument_repr() -> None:
     assert str(instrument.id) in repr_str
     assert "stringed" in repr_str
     session.close()
+    engine.dispose()
 
 
 def test_keyboard_instrument_repr() -> None:
@@ -135,6 +140,7 @@ def test_keyboard_instrument_repr() -> None:
     assert "Yamaha P-125" in repr_str
     assert str(keyboard.id) in repr_str
     session.close()
+    engine.dispose()
 
 
 def test_wind_instrument_repr() -> None:
@@ -153,6 +159,7 @@ def test_wind_instrument_repr() -> None:
     assert "Yamaha YAS-280" in repr_str
     assert str(wind.id) in repr_str
     session.close()
+    engine.dispose()
 
 
 def test_percussion_instrument_repr() -> None:
@@ -171,3 +178,4 @@ def test_percussion_instrument_repr() -> None:
     assert "Pearl Export" in repr_str
     assert str(percussion.id) in repr_str
     session.close()
+    engine.dispose()

--- a/tests/db/test_instrument_technique_relationship.py
+++ b/tests/db/test_instrument_technique_relationship.py
@@ -33,6 +33,7 @@ def test_instrument_can_support_multiple_techniques() -> None:
     assert len(retrieved.techniques) == 3
     assert any(t.name == "string bending" for t in retrieved.techniques)
     session.close()
+    engine.dispose()
 
 
 def test_technique_can_be_supported_by_multiple_instruments() -> None:
@@ -59,3 +60,4 @@ def test_technique_can_be_supported_by_multiple_instruments() -> None:
     assert retrieved_technique is not None
     assert len(retrieved_technique.instruments) == 2
     session.close()
+    engine.dispose()

--- a/tests/db/test_instrument_tuning_relationship.py
+++ b/tests/db/test_instrument_tuning_relationship.py
@@ -41,6 +41,7 @@ def test_stringed_instrument_can_have_multiple_tunings() -> None:
     assert retrieved.tunings[0].name == "Standard"
     assert retrieved.tunings[1].name == "Drop D"
     session.close()
+    engine.dispose()
 
 
 def test_tuning_can_be_used_by_multiple_instruments() -> None:
@@ -77,3 +78,4 @@ def test_tuning_can_be_used_by_multiple_instruments() -> None:
     assert retrieved_tuning is not None
     assert len(retrieved_tuning.instruments) == 2
     session.close()
+    engine.dispose()

--- a/tests/db/test_overload_dimension_model.py
+++ b/tests/db/test_overload_dimension_model.py
@@ -27,6 +27,7 @@ def test_overload_dimension_creation() -> None:
     assert retrieved.description is not None
     assert "beats per minute" in retrieved.description
     session.close()
+    engine.dispose()
 
 
 def test_overload_dimension_unique_name() -> None:
@@ -52,6 +53,7 @@ def test_overload_dimension_unique_name() -> None:
         session.rollback()
     finally:
         session.close()
+        engine.dispose()
 
 
 def test_overload_dimension_repr() -> None:

--- a/tests/db/test_technique_model.py
+++ b/tests/db/test_technique_model.py
@@ -27,6 +27,7 @@ def test_technique_creation() -> None:
     assert retrieved.description is not None
     assert "Skipping over" in retrieved.description
     session.close()
+    engine.dispose()
 
 
 def test_technique_unique_name() -> None:
@@ -52,6 +53,7 @@ def test_technique_unique_name() -> None:
         session.rollback()
     finally:
         session.close()
+        engine.dispose()
 
 
 def test_technique_repr() -> None:

--- a/tests/db/test_tuning_polymorphism.py
+++ b/tests/db/test_tuning_polymorphism.py
@@ -28,6 +28,7 @@ def test_base_tuning_has_discriminator() -> None:
 
     assert tuning.tuning_type == "stringed"
     session.close()
+    engine.dispose()
 
 
 def test_stringed_instrument_tuning_creation() -> None:
@@ -52,6 +53,7 @@ def test_stringed_instrument_tuning_creation() -> None:
     assert retrieved.pitch_sequence == ["E2", "A2", "D3", "G3", "B3", "E4"]
     assert retrieved.tuning_type == "stringed"
     session.close()
+    engine.dispose()
 
 
 def test_placeholder_tunings_exist() -> None:
@@ -72,6 +74,7 @@ def test_placeholder_tunings_exist() -> None:
     assert session.query(WindInstrumentTuning).count() == 1
     assert session.query(PercussionInstrumentTuning).count() == 1
     session.close()
+    engine.dispose()
 
 
 def test_polymorphic_tuning_query() -> None:
@@ -94,6 +97,7 @@ def test_polymorphic_tuning_query() -> None:
     assert isinstance(tunings[0], StringedInstrumentTuning)
     assert isinstance(tunings[1], KeyboardInstrumentTuning)
     session.close()
+    engine.dispose()
 
 
 def test_base_tuning_repr() -> None:
@@ -116,6 +120,7 @@ def test_base_tuning_repr() -> None:
     assert str(tuning.id) in repr_str
     assert "stringed" in repr_str
     session.close()
+    engine.dispose()
 
 
 def test_stringed_instrument_tuning_repr() -> None:
@@ -136,6 +141,7 @@ def test_stringed_instrument_tuning_repr() -> None:
     assert "Drop D" in repr_str
     assert str(tuning.id) in repr_str
     session.close()
+    engine.dispose()
 
 
 def test_keyboard_instrument_tuning_repr() -> None:
@@ -154,6 +160,7 @@ def test_keyboard_instrument_tuning_repr() -> None:
     assert "A440" in repr_str
     assert str(tuning.id) in repr_str
     session.close()
+    engine.dispose()
 
 
 def test_wind_instrument_tuning_repr() -> None:
@@ -172,6 +179,7 @@ def test_wind_instrument_tuning_repr() -> None:
     assert "A442" in repr_str
     assert str(tuning.id) in repr_str
     session.close()
+    engine.dispose()
 
 
 def test_percussion_instrument_tuning_repr() -> None:
@@ -190,3 +198,4 @@ def test_percussion_instrument_tuning_repr() -> None:
     assert "Standard" in repr_str
     assert str(tuning.id) in repr_str
     session.close()
+    engine.dispose()


### PR DESCRIPTION
## Summary
- Dispose per-test SQLite engines after session close.
- Prevent ResourceWarnings from unclosed connections.

## Tests
- python3 scripts/dev/validate_local.py
