### PR TITLE
Document AI service account setup

### DIFF
--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -486,6 +486,23 @@ Co-Authored-By: mnemosys-claude <252602472+mnemosys-claude@users.noreply.github.
 
 **Rationale**: AI is a tool. The human drives decisions, validates outcomes, and remains accountable for the code, while the AI contributors are explicitly visible in GitHub history.
 
+#### Adding a New AI Service Account
+
+When onboarding a new AI tool (e.g., "foo"), create a dedicated GitHub service account to preserve clear attribution.
+
+**Setup Steps**:
+1. Create a GitHub account named `mnemosys-foo`.
+2. Use a Gmail alias for signup (e.g., `w.phillip.moore+mnemosys-foo@gmail.com`) to avoid creating a new inbox.
+3. Enable 2FA and set "Keep my email address private".
+4. Copy the account's GitHub noreply email from Settings → Emails.
+
+**Then update this section** with the new co-author identity:
+```
+Co-Authored-By: mnemosys-foo <ID+mnemosys-foo@users.noreply.github.com>
+```
+
+**Why**: GitHub contributor attribution is email-based. A dedicated service account prevents misattribution to unrelated accounts.
+
 #### CI/CD Integration (Future)
 
 **Status**: Not yet implemented


### PR DESCRIPTION
## Summary
- document how to add new mnemosys-* AI co-author service accounts
- capture Gmail alias flow and required co-author entry update

## Testing
- python3 scripts/dev/validate_local.py
