### PR TITLE
chore: rename nonprod deploy workflow

### DIFF
--- a/.github/workflows/deploy-nonprod.yml
+++ b/.github/workflows/deploy-nonprod.yml
@@ -1,4 +1,4 @@
-name: Deploy Nonprod API
+name: CD - Deploy Nonprod
 
 on:
   push:


### PR DESCRIPTION
## Summary
- rename nonprod deploy workflow to align with CD naming convention

## Testing
- `bash -lc 'set -a; source .env; set +a; source .venv/bin/activate && python scripts/dev/validate_local.py'`
