### PR TITLE
Suppress Testcontainers deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,8 @@ filterwarnings = [
     # Also applies to pytest-cov's internal SQLite usage
     "ignore:unclosed database:ResourceWarning",
     "ignore::ResourceWarning",
+    # Suppress Testcontainers deprecation emitted by dependency internals
+    "ignore:The @wait_container_is_ready decorator is deprecated:DeprecationWarning",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Summary
- suppress the upstream Testcontainers wait_container_is_ready deprecation warning in pytest

## Testing
- .venv/bin/python scripts/dev/validate_local.py
