### PR TITLE
docs: clarify docs-only PR checkpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,10 @@ This project follows a **database-first architecture** with explicit structural 
    ```
 3. **If already on a feature branch**: Continue working on that branch
 
+**Guardrail**: Do not rely on earlier branch checks. Before any edit or commit (even mid-session or docs-only),
+re-run `git branch --show-current`. If you are on `develop`, `release`, or `main`, stop and create a feature
+branch before touching files.
+
 **Why this matters**: Direct commits to `develop` violate the project's branching model. ALL changes to eternal branches (develop/main/release) must go through pull requests.
 
 **Branch naming**:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,11 @@ The 30 seconds spent reading documentation prevents hours of cleanup work.
 
 **CRITICAL**: Always pause and request user confirmation at these checkpoints in the workflow. Never proceed automatically.
 
+**Docs-Only Exception**: If the diff includes **only** documentation files (anything under `docs/` plus top-level
+`README.md` or `CHANGELOG.md`), skip both confirmation checkpoints and proceed directly through PR creation
+and finalization. Local validation is optional per the docs-only rule in `docs/standards-and-conventions.md`.
+If any non-documentation file changes, the checkpoints remain mandatory.
+
 **Checkpoint: Before Creating Pull Request**
 
 After completing work and committing to your feature branch, you MUST validate the code before pushing. **STOP** and follow this sequence:


### PR DESCRIPTION
## Summary
- allow docs-only changes to skip PR confirmation checkpoints
- reinforce branch preflight guardrail in AGENTS

## Testing
- python3 scripts/dev/validate_local.py

Co-Authored-By: mnemosys-codex <252598091+mnemosys-codex@users.noreply.github.com>
