### PR TITLE
docs: reclassify completed plans

### DIFF
--- a/docs/plans/complete/2025-12-30-domain-model-v2-design.md
+++ b/docs/plans/complete/2025-12-30-domain-model-v2-design.md
@@ -1,7 +1,7 @@
 # MNEMOSYS Domain Model v2.0 Design
 
 **Date:** 2025-12-30
-**Status:** Approved for implementation
+**Status:** Completed
 **Scope:** Core domain entities, relationships, and session structure
 
 ---

--- a/docs/plans/complete/2025-12-31-ci-hard-gates-next-steps.md
+++ b/docs/plans/complete/2025-12-31-ci-hard-gates-next-steps.md
@@ -23,6 +23,6 @@ tests/test_code_compliance.py, and add a local validation script.
 5. Updated docs to remove `test_code_compliance.py` references and point to new gates:
    - `AGENTS.md`
    - `docs/standards-and-conventions.md`
-   - `docs/plans/pending/2025-12-31-github-actions-ci-design.md`
+   - `docs/plans/complete/2025-12-31-github-actions-ci-design.md`
    - `docs/plans/complete/2025-12-31-github-actions-ci-implementation.md`
 6. Ran full validation and proceeded with PR/merge per checkpoints.

--- a/docs/plans/complete/2025-12-31-data-model-diagram-generation-design.md
+++ b/docs/plans/complete/2025-12-31-data-model-diagram-generation-design.md
@@ -1,7 +1,7 @@
 # Data Model Diagram Generation Design
 
 **Date:** 2025-12-31
-**Status:** Approved for implementation
+**Status:** Completed
 **Scope:** Automated generation of human-readable ER diagrams from SQLAlchemy models
 
 ---

--- a/docs/plans/complete/2025-12-31-github-actions-ci-design.md
+++ b/docs/plans/complete/2025-12-31-github-actions-ci-design.md
@@ -1,7 +1,7 @@
 # GitHub Actions CI/CD Pipeline Design
 
 **Date**: 2025-12-31
-**Status**: Approved for implementation
+**Status**: Completed
 
 ## Table of Contents
 - [Overview](#overview)

--- a/scripts/dev/generate_diagram.py
+++ b/scripts/dev/generate_diagram.py
@@ -3,7 +3,7 @@
 Generate Mermaid ER diagram from SQLAlchemy models.
 
 This is a prototype implementation to test the design approach documented in
-docs/plans/pending/2025-12-31-data-model-diagram-generation-design.md
+docs/plans/complete/2025-12-31-data-model-diagram-generation-design.md
 """
 
 from collections import defaultdict


### PR DESCRIPTION
## Summary
- move completed plan documents from pending to complete
- update status markers to Completed
- fix references to new locations

## Testing
- python3 scripts/dev/validate_local.py

Docs-only: tests skipped

## Files changed
- docs/plans/complete/2025-12-30-domain-model-v2-design.md
- docs/plans/complete/2025-12-31-data-model-diagram-generation-design.md
- docs/plans/complete/2025-12-31-github-actions-ci-design.md
- docs/plans/complete/2025-12-31-ci-hard-gates-next-steps.md
- scripts/dev/generate_diagram.py
