### PR TITLE
docs: extend test/prod parity plan

### DIFF
--- a/docs/plans/pending/2026-01-07-test-prod-db-parity-plan.md
+++ b/docs/plans/pending/2026-01-07-test-prod-db-parity-plan.md
@@ -1,4 +1,4 @@
-# Test/Production Database Parity Plan (RDS Promotion)
+# Test/Production Environment Parity Plan (RDS + REST API)
 
 **Status:** Draft
 
@@ -17,10 +17,12 @@
 ## Context
 
 The test environment must be a near-identical proxy for production. That requires
-test and production databases to run on the same infrastructure tier with minimal
-configuration drift. To achieve this, we will promote the managed Postgres instance
-used for development into a production-tier configuration and use that pattern for
-the test database (release branch deployments).
+both the database and the REST API to run on the same infrastructure tier with
+minimal configuration drift. To achieve this, we will promote the managed Postgres
+instance used for development into a production-tier configuration and use that
+pattern for the test database (release branch deployments). In parallel, the test
+REST API service must run with production-like resiliency settings so the API and
+database are evaluated together as a matched pair.
 
 This plan builds on:
 - `docs/plans/pending/2026-01-04-aws-nonprod-rest-api-deploy-plan.md`
@@ -29,7 +31,8 @@ This plan builds on:
 ## Goals
 
 - Align test and production database infrastructure tiers.
-- Document the production-grade AWS RDS configuration by applying it to test.
+- Align test and production REST API infrastructure tiers and resiliency settings.
+- Document the production-grade AWS RDS and REST API configuration by applying it to test.
 - Keep dev/test updates strictly pipeline-driven (no local credentials).
 - Preserve "rebuild from scratch" and migration gate behavior.
 
@@ -43,6 +46,8 @@ This plan builds on:
 
 - Test and production use the same engine version, parameter group, instance class,
   storage type, encryption, and backup policies.
+- Test and production REST API services use the same deployment topology,
+  health checks, scaling configuration, and failure handling defaults.
 - Release branch drives test deployments; developers do not hold test credentials.
 - Migration gate remains the only automated schema change path.
 - Any drift between test and production must be intentional, documented, and minimal.
@@ -52,11 +57,13 @@ This plan builds on:
 
 - Nonprod RDS exists and is used by development/test deployments.
 - Development database is on a non-production tier configuration.
+- Test REST API is deployed but not configured for production-grade resiliency.
 - Test database credentials are stored only in AWS (SSM/Secrets), not locally.
 
 ## Target State
 
 - Test database runs on production-tier RDS configuration.
+- Test REST API runs with production-grade resiliency configuration.
 - Configuration parity with production is explicit and enforced.
 - Development remains isolated from test (no shared credentials; no direct access).
 
@@ -66,32 +73,45 @@ This plan builds on:
    - Engine version, instance class, storage type, IOPS, encryption.
    - Parameter group, maintenance window, backup retention.
    - Security groups, subnet group, VPC placement.
-2. Define the production-tier baseline:
+2. Inventory current REST API configuration used by development/test:
+   - ECS service desired count, autoscaling rules, health checks.
+   - Deployment strategy, circuit breaker settings, and timeouts.
+   - Task sizing, CPU/memory, and networking configuration.
+3. Define the production-tier baseline:
    - Instance class and storage class sized for production.
    - Multi-AZ, backup retention, deletion protection, performance insights.
    - Parameter group settings required for production parity.
-3. Destroy and recreate the test database as a clean production-tier instance:
+4. Define the production-tier REST API baseline:
+   - Desired count and autoscaling targets for resiliency.
+   - Health check configuration (ALB + container) and timeouts.
+   - Deployment settings (minimum healthy percent, max percent).
+5. Destroy and recreate the test database as a clean production-tier instance:
    - No data preservation required in the current proof-of-concept phase.
    - Apply instance class, storage, and parameter group changes at creation time.
    - Enforce backups, encryption, monitoring, deletion protection.
-4. Update AWS secrets/SSM parameters for the test environment:
+6. Update AWS secrets/SSM parameters for the test environment:
    - `/mnemosys/test/db/host`, `/mnemosys/test/db/port`, etc.
    - Confirm admin credentials are present and rotate if required.
-5. Validate pipeline behavior:
+7. Update REST API service configuration for test to match production baseline:
+   - Apply scaling, health check, deployment, and resiliency settings.
+   - Confirm task definitions and runtime configuration are aligned with prod.
+8. Validate pipeline behavior:
    - Merge `develop` -> `release` and confirm the migration gate runs against the
      updated test database and succeeds.
    - Confirm application health checks succeed post-deploy.
-6. Document the production-grade RDS configuration and parity rules.
+9. Document the production-grade RDS and REST API configuration and parity rules.
 
 ## Validation
 
 - Release pipeline deploys to test without manual database access.
 - Alembic migration gate applies cleanly and logs expected output.
 - RDS configuration matches the production-tier baseline.
+- REST API service configuration matches the production-tier baseline.
 
 ## Risks
 
 - Misconfigured parameter group or storage settings can cause downtime.
+- REST API resiliency drift can hide production-only failure modes.
 - Drift between test and production if parity rules are not enforced in docs.
 - Instance recreation changes endpoints and requires secrets updates.
 
@@ -99,3 +119,4 @@ This plan builds on:
 
 - Is Multi-AZ required for test (to mirror production) or optional for cost?
 - What are the exact production-tier parameters (instance class, storage size, IOPS)?
+- What are the target REST API resiliency parameters (desired count, autoscaling thresholds)?


### PR DESCRIPTION
## Summary
- expand test/prod parity plan to include REST API resiliency and configuration
- align goals, invariants, plan steps, and validation to cover database + API

## Testing
- not run (docs-only)

Docs-only: tests skipped

## Files changed
- docs/plans/pending/2026-01-07-test-prod-db-parity-plan.md
