### PR TITLE
Fix alembic migration gate logic

### DIFF
--- a/alembic/runner.py
+++ b/alembic/runner.py
@@ -8,6 +8,7 @@ import argparse
 import importlib.util
 import logging
 import os
+import re
 import subprocess
 import sys
 import time
@@ -23,6 +24,7 @@ from mnemosys_core.config.environments import Environment
 from mnemosys_core.config.settings import Settings, load_admin_settings_from_env
 
 LOGGER = logging.getLogger(__name__)
+REVISION_PATTERN = re.compile(r"\b[0-9a-f]{8,}\b")
 
 
 @dataclass(frozen=True)
@@ -135,6 +137,24 @@ def run_alembic_command(
     )
 
 
+def parse_revision_ids(output: str) -> set[str]:
+    """Extract Alembic revision IDs from command output."""
+    return set(REVISION_PATTERN.findall(output))
+
+
+def get_revision_ids(result: AlembicCommandResult) -> set[str]:
+    """Return revision IDs from stdout and stderr."""
+    combined_output = f"{result.standard_output}\n{result.standard_error}"
+    return parse_revision_ids(combined_output)
+
+
+def is_database_at_head(current_revisions: set[str], head_revisions: set[str]) -> bool:
+    """Return True if the database revision set includes all heads."""
+    if not head_revisions:
+        return False
+    return head_revisions.issubset(current_revisions)
+
+
 def log_command_result(
     result: AlembicCommandResult,
     *,
@@ -156,27 +176,56 @@ def log_command_result(
 
 def run_upgrade(alembic_configuration_path: str | None) -> int:
     """Run the automated Alembic upgrade sequence."""
-    check_result = run_alembic_command(["check"], alembic_configuration_path)
-    log_command_result(check_result, log_stderr=check_result.return_code == 0)
-    if check_result.return_code == 0:
-        LOGGER.info("Alembic check succeeded. No upgrade required.")
+    current_result = run_alembic_command(["current"], alembic_configuration_path)
+    log_command_result(current_result)
+    if current_result.return_code != 0:
+        LOGGER.error("Alembic current failed; cannot determine database state.")
+        return 1
+
+    heads_result = run_alembic_command(["heads"], alembic_configuration_path)
+    log_command_result(heads_result)
+    if heads_result.return_code != 0:
+        LOGGER.error("Alembic heads failed; cannot determine head revisions.")
+        return 1
+
+    current_revisions = get_revision_ids(current_result)
+    head_revisions = get_revision_ids(heads_result)
+    if is_database_at_head(current_revisions, head_revisions):
+        LOGGER.info("Database is at head revisions: %s", ", ".join(sorted(head_revisions)))
         return 0
 
-    LOGGER.info("Alembic check indicates pending migrations. Attempting upgrade.")
+    LOGGER.info(
+        "Database revisions %s do not match heads %s; attempting upgrade.",
+        ", ".join(sorted(current_revisions)) or "<none>",
+        ", ".join(sorted(head_revisions)) or "<none>",
+    )
     upgrade_result = run_alembic_command(["upgrade", "heads"], alembic_configuration_path)
     log_command_result(upgrade_result)
     if upgrade_result.return_code == 0:
-        LOGGER.info("Alembic upgrade completed successfully.")
-        return 0
+        recheck_result = run_alembic_command(["current"], alembic_configuration_path)
+        log_command_result(recheck_result)
+        if recheck_result.return_code != 0:
+            LOGGER.error("Alembic current failed after upgrade.")
+            return 1
+        updated_revisions = get_revision_ids(recheck_result)
+        if is_database_at_head(updated_revisions, head_revisions):
+            LOGGER.info("Alembic upgrade completed successfully.")
+            return 0
+        LOGGER.error("Database remains out of sync after successful upgrade.")
+        return 1
 
-    LOGGER.warning("Alembic upgrade failed. Re-checking schema state.")
-    recheck_result = run_alembic_command(["check"], alembic_configuration_path)
+    LOGGER.warning("Alembic upgrade failed. Re-checking database state.")
+    recheck_result = run_alembic_command(["current"], alembic_configuration_path)
     log_command_result(recheck_result)
-    if recheck_result.return_code == 0:
-        LOGGER.warning("Schema is now at head after failed upgrade; assuming concurrency.")
+    if recheck_result.return_code != 0:
+        LOGGER.error("Alembic current failed after upgrade failure.")
+        return 1
+    updated_revisions = get_revision_ids(recheck_result)
+    if is_database_at_head(updated_revisions, head_revisions):
+        LOGGER.warning("Database is now at head after failed upgrade; assuming concurrency.")
         return 0
 
-    LOGGER.error("Schema remains out of sync after failed upgrade.")
+    LOGGER.error("Database remains out of sync after failed upgrade.")
     return 1
 
 

--- a/docs/operations/2026-01-12-18-31-nonprod-parity-ops.md
+++ b/docs/operations/2026-01-12-18-31-nonprod-parity-ops.md
@@ -1,0 +1,121 @@
+## Actions Taken
+- Note: CLI command timestamps were not captured in the chat; filename timestamp is UTC 2026-01-12 18:31.
+- Verified AWS identity.
+  Command: `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws sts get-caller-identity`
+  Output: `{"Account":"959713283130","Arn":"arn:aws:iam::959713283130:user/mnemosys-admin"}`
+- Checked for existing test RDS instance.
+  Command: `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws rds describe-db-instances --db-instance-identifier mnemosys-test-postgres --query "DBInstances[0].DBInstanceStatus" --output text`
+  Output: `DBInstanceNotFound` error.
+- Attempted RDS create with explicit IOPS/throughput.
+  Command: `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws rds create-db-instance --db-instance-identifier mnemosys-test-postgres --db-instance-class db.t4g.large --engine postgres --engine-version 16.11 --db-name mnemosys_test --allocated-storage 200 --storage-type gp3 --iops 3000 --storage-throughput 125 --backup-retention-period 35 --multi-az --publicly-accessible --storage-encrypted --deletion-protection --enable-performance-insights --performance-insights-retention-period 7 --db-subnet-group-name default-vpc-06f003b77e593c99a --vpc-security-group-ids sg-0463c511b48bcbef5`
+  Output: `InvalidParameterCombination: You can't specify IOPS or storage throughput for engine postgres and a storage size less than 400.`
+- Created test RDS instance without explicit IOPS/throughput.
+  Command: `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws rds create-db-instance --db-instance-identifier mnemosys-test-postgres --db-instance-class db.t4g.large --engine postgres --engine-version 16.11 --db-name mnemosys_test --allocated-storage 200 --storage-type gp3 --backup-retention-period 35 --multi-az --publicly-accessible --storage-encrypted --deletion-protection --enable-performance-insights --performance-insights-retention-period 7 --db-subnet-group-name default-vpc-06f003b77e593c99a --vpc-security-group-ids sg-0463c511b48bcbef5`
+  Output: `"DBInstanceIdentifier":"mnemosys-test-postgres","DBInstanceStatus":"creating","MultiAZ":true` (truncated).
+- Waited for RDS availability.
+  Commands:
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws rds wait db-instance-available --db-instance-identifier mnemosys-test-postgres` (timed out after 600s)
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws rds describe-db-instances --db-instance-identifier mnemosys-test-postgres --query "DBInstances[0].DBInstanceStatus" --output text` -> `modifying`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws rds wait db-instance-available --db-instance-identifier mnemosys-test-postgres` (succeeded; no output)
+- Retrieved endpoint and updated SSM parameters.
+  Commands:
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws rds describe-db-instances --db-instance-identifier mnemosys-test-postgres --query "DBInstances[0].Endpoint.Address" --output text`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ssm put-parameter --name /mnemosys/test/db/host --type SecureString --value "${TEST_ENDPOINT}" --overwrite`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ssm put-parameter --name /mnemosys/test/db/port --type SecureString --value "5432" --overwrite`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ssm put-parameter --name /mnemosys/test/db/database --type SecureString --value "mnemosys_test" --overwrite`
+  Output: endpoint `mnemosys-test-postgres.c3uamoeq6wst.us-east-2.rds.amazonaws.com`; SSM responses `{"Version":2,"Tier":"Standard"}` (x3).
+- Forced test ECS deployment and waited for stability.
+  Commands:
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ecs update-service --cluster mnemosys-nonprod --service mnemosys-test-api --force-new-deployment`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ecs wait services-stable --cluster mnemosys-nonprod --services mnemosys-test-api`
+  Output: waiter failed `Waiter ServicesStable failed: Max attempts exceeded`.
+- Investigated ECS failures.
+  Commands:
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ecs list-tasks --cluster mnemosys-nonprod --service-name mnemosys-test-api --desired-status STOPPED --max-items 5`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ecs describe-tasks --cluster mnemosys-nonprod --tasks <task-arns> --query "tasks[*].{taskArn:taskArn,lastStatus:lastStatus,stoppedReason:stoppedReason,containers:containers[*].{name:name,exitCode:exitCode,reason:reason}}" --output json`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws logs get-log-events --log-group-name /mnemosys/test/api --log-stream-name mnemosys/mnemosys-api/b4158f108f9e4d7d8a588857386c0d7a --limit 50 --no-start-from-head --query "events[*].message" --output json`
+  Output: tasks exited with `exitCode: 1`; log excerpt shows `sqlalchemy.exc.ProgrammingError: ... schema "mnemosys" does not exist` (truncated).
+- Created schema in new test database and conditionally granted access.
+  Command:
+  - `ADMIN_USER=$(AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ssm get-parameter --name /mnemosys/test/db_admin/username --with-decryption --query "Parameter.Value" --output text)`
+  - `ADMIN_PASS=$(AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ssm get-parameter --name /mnemosys/test/db_admin/password --with-decryption --query "Parameter.Value" --output text)`
+  - `APP_USER=$(AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ssm get-parameter --name /mnemosys/test/db/username --with-decryption --query "Parameter.Value" --output text)`
+  - `DB_HOST=$(AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ssm get-parameter --name /mnemosys/test/db/host --with-decryption --query "Parameter.Value" --output text)`
+  - `DB_NAME=$(AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ssm get-parameter --name /mnemosys/test/db/database --with-decryption --query "Parameter.Value" --output text)`
+  - `DB_SSLMODE=$(AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ssm get-parameter --name /mnemosys/test/db/sslmode --with-decryption --query "Parameter.Value" --output text)`
+  - `PGPASSWORD="$ADMIN_PASS" psql "host=$DB_HOST dbname=$DB_NAME user=$ADMIN_USER sslmode=$DB_SSLMODE" -v ON_ERROR_STOP=1 -c "CREATE SCHEMA IF NOT EXISTS mnemosys;"`
+  - `ROLE_EXISTS=$(PGPASSWORD="$ADMIN_PASS" psql "host=$DB_HOST dbname=$DB_NAME user=$ADMIN_USER sslmode=$DB_SSLMODE" -tAc "SELECT 1 FROM pg_roles WHERE rolname='${APP_USER}';")`
+  - `PGPASSWORD="$ADMIN_PASS" psql "host=$DB_HOST dbname=$DB_NAME user=$ADMIN_USER sslmode=$DB_SSLMODE" -v ON_ERROR_STOP=1 -c "GRANT USAGE, CREATE ON SCHEMA mnemosys TO \"${APP_USER}\";"` (conditional)
+  Output: `CREATE SCHEMA`.
+- Forced ECS deployment again and waited for stability.
+  Commands:
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ecs update-service --cluster mnemosys-nonprod --service mnemosys-test-api --force-new-deployment`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ecs wait services-stable --cluster mnemosys-nonprod --services mnemosys-test-api`
+  Output: waiter succeeded (no output).
+- Updated test ECS baseline and waited for stability.
+  Commands:
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ecs update-service --cluster mnemosys-nonprod --service mnemosys-test-api --desired-count 2 --health-check-grace-period-seconds 180 --deployment-configuration "minimumHealthyPercent=100,maximumPercent=200,deploymentCircuitBreaker={enable=true,rollback=true}"`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ecs wait services-stable --cluster mnemosys-nonprod --services mnemosys-test-api`
+  Output: wait succeeded (no output).
+- Verified autoscaling, health checks, and final RDS config.
+  Commands:
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws application-autoscaling describe-scalable-targets --service-namespace ecs --resource-ids service/mnemosys-nonprod/mnemosys-test-api --query "ScalableTargets" --output json`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws elbv2 describe-load-balancers --names mnemosys-nonprod-alb --query "LoadBalancers[0].DNSName" --output text`
+  - `curl -fsSL http://mnemosys-nonprod-alb-1104521642.us-east-2.elb.amazonaws.com/health/`
+  - `curl -fsSL http://mnemosys-nonprod-alb-1104521642.us-east-2.elb.amazonaws.com:8080/health/`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws rds describe-db-instances --db-instance-identifier mnemosys-test-postgres --query "DBInstances[0].{status:DBInstanceStatus,engine:Engine,engineVersion:EngineVersion,instanceClass:DBInstanceClass,allocatedStorage:AllocatedStorage,iops:Iops,storageThroughput:StorageThroughput,multiAZ:MultiAZ,backupRetention:BackupRetentionPeriod,public:PubliclyAccessible,deletionProtection:DeletionProtection,performanceInsights:PerformanceInsightsEnabled,storageType:StorageType,endpoint:Endpoint.Address}" --output json`
+  Output: autoscaling `[]`; health checks `{"status":"ok"}`; RDS `status: available`, `MultiAZ: true`, `allocatedStorage: 200`, `backupRetention: 35`, endpoint `mnemosys-test-postgres.c3uamoeq6wst.us-east-2.rds.amazonaws.com` (truncated).
+- Checked migration gate outcomes in logs.
+  Command: `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws logs filter-log-events --log-group-name /mnemosys/test/api --filter-pattern "Command finished with code" --limit 20 --query "events[*].message" --output json`
+  Output: includes `Command finished with code 0 in 4.98s: /usr/local/bin/python -m alembic upgrade heads` (truncated).
+- Inspected deploy workflow for release/test mapping.
+  Command: `cat .github/workflows/deploy-nonprod.yml`
+  Output: `on: push: branches: [develop, release]` and `release -> test` mapping (truncated).
+- Compared release vs develop history to scope the release promotion.
+  Commands:
+  - `git fetch origin`
+  - `git log --oneline origin/release..origin/develop`
+  Output: multiple commits ahead of release (truncated).
+- Searched test task logs for migration gate outcomes (per-task log streams).
+  Commands:
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ecs list-tasks --cluster mnemosys-nonprod --service-name mnemosys-test-api --desired-status RUNNING --query "taskArns" --output text`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws logs get-log-events --log-group-name /mnemosys/test/api --log-stream-name mnemosys/mnemosys-api/<task-id> --limit 200 --no-start-from-head --query "events[*].message" --output text | rg -n "alembic|Migration runner|Command finished"`
+  Output: `Command finished with code 255 ... alembic check` (e.g., `Target database is not up to date`, `remove_table alembic_version`), followed by `Command finished with code 0 ... alembic upgrade heads` and successful startup logs (truncated).
+- Ran local validation on develop; first attempt failed due to missing Docker daemon.
+  Command: `python3 scripts/dev/validate_local.py`
+  Output: `docker.errors.DockerException: Error while fetching server API version: ... FileNotFoundError(2, 'No such file or directory')` (truncated).
+- Re-ran local validation after Docker started.
+  Command: `python3 scripts/dev/validate_local.py`
+  Output: `184 passed in 24.46s` with coverage 100% and ruff/mypy success (truncated).
+
+## Outcomes and Status
+- Test RDS instance `mnemosys-test-postgres` created and available; config matches locked baseline (db.t4g.large, gp3 200GB, Multi-AZ true, backup retention 35, deletion protection true, Performance Insights enabled).
+- `/mnemosys/test/db/host`, `/mnemosys/test/db/port`, and `/mnemosys/test/db/database` updated to the new RDS endpoint.
+- ECS test service stabilized after schema creation; service now at desired 2 / running 2 with circuit breaker enabled and health check grace 180s.
+- Autoscaling remains off (no scalable targets).
+- ALB health checks return `{"status":"ok"}` for dev (port 80) and test (port 8080).
+- Migration gate now shows `alembic check` failures in test task logs (target DB not up to date / remove `alembic_version`), followed by successful `alembic upgrade heads`.
+- Local validation on develop succeeded after Docker startup.
+- Release -> test pipeline validation remains pending (release is behind develop and requires PR-based promotion).
+
+## Problems Encountered and Solved
+- RDS create failed with `InvalidParameterCombination` when specifying IOPS/throughput at 200GB; resolved by omitting explicit IOPS/throughput (gp3 defaults applied).
+- RDS wait timed out while instance still `modifying`; resolved by rechecking status and waiting again.
+- ECS tasks exited with code 1 due to `schema "mnemosys" does not exist`; resolved by creating the schema in the new test database and redeploying.
+- CloudWatch log retrieval initially failed with `Unknown options: false` for `--start-from-head false` and with `ResourceNotFoundException` for a missing log stream; resolved by using `--no-start-from-head` and targeting an existing log stream.
+- Local validation failed due to Docker daemon not running; resolved by starting Docker and rerunning `validate_local.py`.
+
+## Problems Unresolved
+- `alembic check` fails in test task logs (e.g., `Target database is not up to date` and `remove_table alembic_version`), indicating bootstrap/migration gate issues that need triage.
+- Release -> test pipeline validation not run; promotion requires PR from develop to release.
+
+## Changes and Artifacts
+- Created RDS instance `mnemosys-test-postgres` (new dedicated test DB).
+- Updated SSM parameters `/mnemosys/test/db/host`, `/mnemosys/test/db/port`, `/mnemosys/test/db/database` to the new endpoint.
+- Created schema `mnemosys` in the new test database (and conditionally granted schema privileges to the app user if present).
+- Updated ECS service `mnemosys-test-api` to desired count 2 with deployment circuit breaker enabled and health check grace period 180s.
+- Created `docs/operations/2026-01-12-18-31-nonprod-parity-ops.md` (this summary).
+
+## Follow-up Work and New Issues
+- Triage `alembic check` failures in test bootstrap (especially `alembic_version` removal) and determine corrective action.
+- Run release -> test pipeline validation (develop -> release PR and deploy) after triage and capture migration gate evidence.

--- a/docs/plans/in-progress/2026-01-03-alembic-schema-management-design.md
+++ b/docs/plans/in-progress/2026-01-03-alembic-schema-management-design.md
@@ -117,13 +117,13 @@ The REST API startup sequence must run an explicit migration gate before the API
 
 Required behavior:
 1. Read `MNEMOSYS_ENV` and database credentials (`MNEMOSYS_DB_ADMIN_*` with fallback to `MNEMOSYS_DB_*`).
-2. Run `alembic check` to compare database revision to `heads`.
-3. If check succeeds, start the API service.
-4. If check fails, run `alembic upgrade heads` (transactional).
-5. If upgrade succeeds, start the API service.
-6. If upgrade fails, re-run `alembic check`:
-   - If check succeeds now, assume another process won the race and proceed.
-   - If check still fails, treat the upgrade failure as fatal and stop startup.
+2. Run `alembic current` and `alembic heads` to compare database revisions to head.
+3. If current includes all head revisions, start the API service.
+4. If current does not include head, run `alembic upgrade heads` (transactional).
+5. If upgrade succeeds, re-run `alembic current` and confirm head is present, then start the API service.
+6. If upgrade fails, re-run `alembic current`:
+   - If current includes head now, assume another process won the race and proceed.
+   - If current still does not include head, treat the upgrade failure as fatal and stop startup.
 
 Fail-closed rules:
 - If `alembic check` fails after a failed upgrade attempt, stop startup and fail loudly.
@@ -301,11 +301,11 @@ This section defines the required contract for the startup migration runner. Imp
 ### Behavior (Idempotent)
 
 **Upgrade runner**
-- Run `alembic check`.
-- If check fails, run `alembic upgrade heads`.
-- If upgrade fails, re-run `alembic check`.
-- Exit success if check succeeds at the end of the sequence.
-- Exit failure if check fails after a failed upgrade attempt.
+- Run `alembic current` and `alembic heads`.
+- If current does not include head, run `alembic upgrade heads`.
+- If upgrade fails, re-run `alembic current`.
+- Exit success if current includes head at the end of the sequence.
+- Exit failure if current does not include head after a failed upgrade attempt.
 
 **Downgrade runner**
 - Run `alembic downgrade <target>`.
@@ -323,7 +323,7 @@ This section defines the required contract for the startup migration runner. Imp
 
 - Emit start/end markers.
 - Log environment name and database host (redact credentials).
-- Log `alembic check` result.
+- Log `alembic current` and `alembic heads` results.
 - Log upgrade attempt status and elapsed time.
 - On failure, emit a short reason and exit code.
 

--- a/docs/plans/pending/2026-01-04-aws-nonprod-rest-api-deploy-plan.md
+++ b/docs/plans/pending/2026-01-04-aws-nonprod-rest-api-deploy-plan.md
@@ -4,7 +4,14 @@
 **Status**: In progress (bootstrap complete; parity pending)
 **Last verified**: 2026-01-12
 
+## Resume Here (Ops)
+
+- Use this doc as the single source of truth for nonprod bootstrap + parity.
+- Execute Step 3 (test RDS rebuild) runbook, then Step 4 (test ECS baseline update).
+- Finish with Step 5 validation (release -> test, migration gate, health checks).
+
 ## Table of Contents
+- [Resume Here (Ops)](#resume-here-ops)
 - [Overview](#overview)
 - [Scope](#scope)
 - [Non-Goals](#non-goals)

--- a/docs/plans/pending/2026-01-04-aws-nonprod-rest-api-deploy-plan.md
+++ b/docs/plans/pending/2026-01-04-aws-nonprod-rest-api-deploy-plan.md
@@ -1,7 +1,8 @@
 # AWS Nonprod REST API Deployment Plan (Bootstrap v0.1)
 
 **Date**: 2026-01-04
-**Status**: Draft
+**Status**: In progress (bootstrap complete; parity pending)
+**Last verified**: 2026-01-12
 
 ## Table of Contents
 - [Overview](#overview)
@@ -22,9 +23,11 @@
   - [Step 6: ECS task definitions and services](#step-6-ecs-task-definitions-and-services)
   - [Step 7: GitHub Actions deployment](#step-7-github-actions-deployment)
   - [Step 8: Validation](#step-8-validation)
+- [Implementation Status (Verified 2026-01-12)](#implementation-status-verified-2026-01-12)
+- [Test/Production Parity Plan (Consolidated)](#testproduction-parity-plan-consolidated)
 - [Known Issues](#known-issues)
 - [Open Questions (Deferred)](#open-questions-deferred)
-- [Bootstrap Outputs (Current State)](#bootstrap-outputs-current-state)
+- [Bootstrap Outputs (Verified 2026-01-12)](#bootstrap-outputs-verified-2026-01-12)
 
 ## Overview
 
@@ -38,12 +41,17 @@ The initial implementation uses **minimal AWS infrastructure** (default VPC, HTT
 to reduce bootstrap friction, while preserving a clean migration path to a dedicated VPC
 and TLS-based routing later.
 
+This plan now consolidates the test/production parity work from
+`docs/plans/pending/2026-01-07-test-prod-db-parity-plan.md` to prevent
+rework in deployment automation.
+
 ## Scope
 
 - Nonprod AWS infrastructure for REST API deployment (development + test).
 - AWS CLI-first provisioning and updates.
 - GitHub Actions automation for deploys on `develop` and `release`.
 - Runtime contract for migration gate + API startup.
+- Test/production parity definition and rollout sequencing (RDS + REST API).
 
 ## Non-Goals
 
@@ -115,8 +123,8 @@ Minimal bootstrap must not block a dedicated VPC/TLS setup. To preserve the path
 - Keep all sensitive values in Secrets Manager/SSM from day one.
 - Avoid hardcoding VPC IDs or subnet IDs in code; use variables in CLI scripts.
 
-See `docs/plans/pending/2026-01-07-test-prod-db-parity-plan.md` for the test/production
-database parity and RDS recreation plan.
+See [Test/Production Parity Plan (Consolidated)](#testproduction-parity-plan-consolidated)
+for the test/production database parity and RDS recreation plan.
 
 ## Runtime Contract (Migration Gate)
 
@@ -388,6 +396,186 @@ curl -fsSL http://<alb-dns>/health/
 curl -fsSL http://<alb-dns>:8080/health/
 ```
 
+## Implementation Status (Verified 2026-01-12)
+
+- Step 0: Complete. `Dockerfile`, `scripts/runtime/entrypoint.sh`,
+  `src/mnemosys_core/api/runtime.py`, `infra/ecs/task-def-template.json`,
+  `scripts/deploy/render_task_definition.py`, `scripts/deploy/render_iam_templates.py`,
+  `infra/iam/*.json`, and `.github/workflows/deploy-nonprod.yml` exist.
+- Step 1: Complete. Default VPC `vpc-06f003b77e593c99a` with subnets
+  `subnet-0c174c9ad03ad6808`, `subnet-07ebe0f6e86eb955b`,
+  `subnet-017aaa23437259fa2`.
+- Step 2: Complete. ALB SG `sg-0899f0b2207153896` allows 80/8080 from 0.0.0.0/0.
+  ECS SG `sg-069f915c6fc98b0a6` allows 8000 from ALB SG.
+  RDS SG `sg-0463c511b48bcbef5` allows 5432 from ECS SG (plus user IP).
+- Step 3: Complete. ECR repo `mnemosys-core` exists. Log groups exist at
+  `/mnemosys/dev/api` and `/mnemosys/test/api`.
+- Step 4: Complete. IAM roles exist (`mnemosys-ecs-task-exec`, `mnemosys-ecs-task`,
+  `mnemosys-gha-deploy`) and include SSM read + KMS decrypt. GitHub OIDC provider exists.
+- Step 5: Complete. ECS cluster `mnemosys-nonprod` active. ALB listeners:
+  80 -> dev target group, 8080 -> test target group.
+- Step 6: Complete. Services running with one task each.
+  Dev task definition `mnemosys-development-api:22` uses ECR tag
+  `0aa05c9dfd551f34cc99d09c1137c856783ea148`.
+  Test task definition `mnemosys-test-api:1` uses ECR tag `bootstrap-20260104104343`
+  (release pipeline not updated since bootstrap).
+- Step 7: Complete in repo and IAM. Workflow exists at
+  `.github/workflows/deploy-nonprod.yml`. OIDC role `mnemosys-gha-deploy` exists.
+  Repository variables (`AWS_ACCOUNT_ID`, `AWS_OIDC_ROLE_ARN`) not verified here.
+- Step 8: Complete. `/health/` returns 200 for both listeners.
+- Test/Dev DB state: SSM parameters exist for both environments and currently
+  point to the same RDS host with separate databases (`mnemosys_dev`, `mnemosys_test`).
+
+## Test/Production Parity Plan (Consolidated)
+
+This section replaces `docs/plans/pending/2026-01-07-test-prod-db-parity-plan.md`.
+Do not execute test/prod parity changes until the baseline decisions are explicit.
+
+### Baseline Decisions (Locked 2026-01-12)
+
+RDS (test):
+
+- Dedicated test instance: required (no longer share dev host).
+- Instance identifier: `mnemosys-test-postgres`.
+- Engine/version: Postgres 16.11 (match current).
+- Instance class: `db.t4g.large` (initial; tuning allowed later).
+- Storage: `gp3` 200 GB, 3000 IOPS, 125 MB/s (initial; tuning allowed later).
+- Multi-AZ: **true** (required for production-intent redundancy).
+- Backup retention: 35 days (initial; adjust later).
+- Deletion protection: true.
+- Performance Insights: enabled, 7-day retention (initial; adjust later).
+- Parameter group: `default.postgres16` (initial; custom group later if needed).
+- Public accessibility: **true for bootstrap** (explicit parity exception until
+  private subnets/VPC migration exists).
+- Subnet group: default VPC subnets (explicit parity exception).
+
+REST API (test):
+
+- Desired count: 2 (minimum redundancy).
+- Autoscaling: off (explicit parity exception during bootstrap).
+- Deployment configuration: minimum healthy percent 100, maximum percent 200.
+- Deployment circuit breaker: enabled with rollback.
+- Health check grace period: 180s.
+- Task sizing: CPU 256, memory 512 (explicit parity exception during bootstrap).
+
+1. Inventory current RDS configuration (already captured in Bootstrap Outputs) and
+   document the delta against the locked baseline above.
+2. Inventory current REST API configuration (desired count, autoscaling, deployment
+   configuration, task sizing, health checks).
+3. Recreate the test database instance (`mnemosys-test-postgres`) to match the locked
+   baseline, then update `/mnemosys/test/db/*` parameters (and `/mnemosys/test/db_admin/*`
+   if credentials are rotated).
+4. Update test ECS service to match the REST API baseline (desired count, deployment
+   configuration, circuit breaker, health check grace period, task sizing).
+5. Validate release pipeline behavior (release -> test), ensure migration gate runs,
+   and confirm health checks succeed post-deploy.
+6. Document parity rules and drift exceptions explicitly in this plan.
+
+Step 3 execution (test RDS rebuild):
+
+If rotating admin credentials, update the `/mnemosys/test/db_admin/*` parameters
+before creating the new instance.
+
+```bash
+TEST_ADMIN_USERNAME=$(aws ssm get-parameter \
+  --name /mnemosys/test/db_admin/username \
+  --with-decryption \
+  --query "Parameter.Value" \
+  --output text)
+
+TEST_ADMIN_PASSWORD=$(aws ssm get-parameter \
+  --name /mnemosys/test/db_admin/password \
+  --with-decryption \
+  --query "Parameter.Value" \
+  --output text)
+
+aws rds create-db-instance \
+  --db-instance-identifier mnemosys-test-postgres \
+  --db-instance-class db.t4g.large \
+  --engine postgres \
+  --engine-version 16.11 \
+  --db-name mnemosys_test \
+  --master-username "${TEST_ADMIN_USERNAME}" \
+  --master-user-password "${TEST_ADMIN_PASSWORD}" \
+  --allocated-storage 200 \
+  --storage-type gp3 \
+  --iops 3000 \
+  --storage-throughput 125 \
+  --backup-retention-period 35 \
+  --multi-az \
+  --publicly-accessible \
+  --storage-encrypted \
+  --deletion-protection \
+  --enable-performance-insights \
+  --performance-insights-retention-period 7 \
+  --db-subnet-group-name default-vpc-06f003b77e593c99a \
+  --vpc-security-group-ids sg-0463c511b48bcbef5
+
+aws rds wait db-instance-available \
+  --db-instance-identifier mnemosys-test-postgres
+
+TEST_ENDPOINT=$(aws rds describe-db-instances \
+  --db-instance-identifier mnemosys-test-postgres \
+  --query "DBInstances[0].Endpoint.Address" \
+  --output text)
+
+aws ssm put-parameter \
+  --name /mnemosys/test/db/host \
+  --type SecureString \
+  --value "${TEST_ENDPOINT}" \
+  --overwrite
+
+aws ssm put-parameter \
+  --name /mnemosys/test/db/port \
+  --type SecureString \
+  --value "5432" \
+  --overwrite
+
+aws ssm put-parameter \
+  --name /mnemosys/test/db/database \
+  --type SecureString \
+  --value "mnemosys_test" \
+  --overwrite
+
+aws ecs update-service \
+  --cluster mnemosys-nonprod \
+  --service mnemosys-test-api \
+  --force-new-deployment
+
+aws ecs wait services-stable \
+  --cluster mnemosys-nonprod \
+  --services mnemosys-test-api
+```
+
+Optional cleanup: drop the `mnemosys_test` database from the shared dev instance
+once the new test instance is live to prevent accidental use.
+
+Step 4 execution (test):
+
+```bash
+aws ecs update-service \
+  --cluster mnemosys-nonprod \
+  --service mnemosys-test-api \
+  --desired-count 2 \
+  --health-check-grace-period-seconds 180 \
+  --deployment-configuration "minimumHealthyPercent=100,maximumPercent=200,deploymentCircuitBreaker={enable=true,rollback=true}"
+
+aws ecs wait services-stable \
+  --cluster mnemosys-nonprod \
+  --services mnemosys-test-api
+```
+
+If task sizing changes later, re-render and register a new task definition before
+running the `update-service` step.
+
+Autoscaling remains off during bootstrap; confirm no scalable target exists:
+
+```bash
+aws application-autoscaling describe-scalable-targets \
+  --service-namespace ecs \
+  --resource-ids service/mnemosys-nonprod/mnemosys-test-api
+```
+
 ## Known Issues
 
 - `brew install --cask docker` can time out during Docker Desktop download; current Docker 20.10.12 is sufficient for nonprod builds.
@@ -400,7 +588,7 @@ curl -fsSL http://<alb-dns>:8080/health/
 - Do we want separate ALBs for dev/test or keep shared until prod?
 - Should migration gate run in container entrypoint or init task?
 
-## Bootstrap Outputs (Current State)
+## Bootstrap Outputs (Verified 2026-01-12)
 
 Captured from the initial bootstrap run (update if re-provisioned):
 
@@ -411,6 +599,10 @@ Captured from the initial bootstrap run (update if re-provisioned):
 - RDS instance: `mnemosys-postgres`
 - RDS endpoint: `mnemosys-postgres.c3uamoeq6wst.us-east-2.rds.amazonaws.com`
 - RDS SG: `sg-0463c511b48bcbef5`
+- RDS configuration: `db.t4g.large`, Postgres `16.11`, `gp3` 200 GB, 3000 IOPS,
+  Multi-AZ `false`, backup retention `7`, deletion protection `true`,
+  performance insights `enabled`.
+- Dev/Test DB names: `mnemosys_dev`, `mnemosys_test` (shared RDS host).
 - ALB name: `mnemosys-nonprod-alb`
 - ALB DNS: `mnemosys-nonprod-alb-1104521642.us-east-2.elb.amazonaws.com`
 - ALB SG: `sg-0899f0b2207153896`

--- a/docs/plans/pending/2026-01-07-test-prod-db-parity-plan.md
+++ b/docs/plans/pending/2026-01-07-test-prod-db-parity-plan.md
@@ -1,6 +1,9 @@
 # Test/Production Environment Parity Plan (RDS + REST API)
 
-**Status:** Draft
+**Status:** Merged into `docs/plans/pending/2026-01-04-aws-nonprod-rest-api-deploy-plan.md`
+
+This plan is consolidated into the nonprod deployment plan. Do not execute it
+independently; use the consolidated plan instead.
 
 ## Table of Contents
 - [Context](#context)


### PR DESCRIPTION
## Summary
- compare alembic current vs heads in migration gate and upgrade when behind
- update alembic schema management design doc
- record nonprod parity ops log

## Testing
- python3 scripts/dev/validate_local.py
