### PR TITLE
chore: add PR submission automation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ git checkout -b feature/add-caching-layer
 git add .
 git commit -m "..."
 
-# Push and create PR
+# Push and submit PR
 git push -u origin feature/add-caching-layer
 gh pr create --base develop --title "..." --body "..."
 ```
@@ -157,13 +157,18 @@ and finalization. Local validation is optional per the docs-only rule in
 https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/pull-request-workflow.md.
 If any non-documentation file changes, the checkpoints remain mandatory.
 
-**Checkpoint: Before Creating Pull Request**
+**Finalize Override**: If the user explicitly says **"Finalize PR"**, treat that as approval to submit and
+finalize the PR for the current work without asking for "Submit PR?" or "Finalize PR?" again. This
+permission expires as soon as new work is performed, defined as any new commit or any new file
+modification after the approval is granted.
+
+**Checkpoint: Before Submitting Pull Request**
 
 After completing work and committing to your feature branch, you MUST validate the code before pushing. **STOP** and follow this sequence:
 
 **REQUIRED PRE-PUSH VALIDATION:**
 
-Before pushing the branch or creating a PR, you MUST run and pass the full local validation:
+Before pushing the branch or submitting a PR, you MUST run and pass the full local validation:
 
 ```bash
 # Run local validation (mirrors CI hard gates)
@@ -186,29 +191,29 @@ python scripts/dev/validate_local.py
 **After validation passes, STOP and ask:**
 
 ```
-Create PR?
+Submit PR?
 ```
 
 **What this gives the user:**
 - Opportunity to review the work before it becomes a PR
 - Chance to decide if the work is actually complete
-- Ability to request additional changes before PR creation
+- Ability to request additional changes before PR submission
 - Control over the workflow pace
 
-**Only proceed with PR creation after explicit user approval.**
+**Only proceed with PR submission after explicit user approval** (or the Finalize Override above).
 
 **Workflow sequence:**
 1. Complete work on feature branch
 2. Commit changes locally
 3. 🔍 **VALIDATE** - Run all tests and quality checks (MUST PASS)
-4. ⏸️ **PAUSE** - Ask: "Create PR?"
+4. ⏸️ **PAUSE** - Ask: "Submit PR?"
 5. Wait for user response
-6. If approved: Push branch and create PR
+6. If approved: Push branch and submit PR
 7. If not approved: Make requested changes, go back to step 2
 
 **Checkpoint: Before Finalizing Pull Request**
 
-After creating the PR, **STOP** and ask:
+After submitting the PR, **STOP** and ask (unless the Finalize Override above applies):
 
 ```
 Finalize PR?
@@ -227,15 +232,15 @@ Finalize PR?
 - Ability to add reviewers or request changes
 - Control over when changes land in develop
 
-**Only proceed with PR finalization after explicit user approval.**
+**Only proceed with PR finalization after explicit user approval** (or the Finalize Override above).
 
 **Complete workflow with both checkpoints:**
 1. Complete work on feature branch
 2. Commit changes locally
 3. 🔍 **VALIDATE** - Run all tests and quality checks (MUST PASS before proceeding)
-4. ⏸️ **PAUSE #1** - Ask: "Create PR?"
-5. If approved: Push branch and create PR
-6. ⏸️ **PAUSE #2** - Ask: "Finalize PR?"
+4. ⏸️ **PAUSE #1** - Ask: "Submit PR?" (unless Finalize Override is active)
+5. If approved: Push branch and submit PR
+6. ⏸️ **PAUSE #2** - Ask: "Finalize PR?" (unless Finalize Override is active)
 7. If approved: Execute finalization (merge, update develop, verify .venv, validate)
 8. If not approved: Wait for user to review/request changes
 

--- a/docs/plans/complete/2025-12-31-github-actions-ci-implementation.md
+++ b/docs/plans/complete/2025-12-31-github-actions-ci-implementation.md
@@ -314,7 +314,7 @@ Status check:
 - ✅ All local tests passing
 - ✅ CI workflow passing on GitHub
 
-Next: Create PR following standard process (validation → user approval → push → create PR → finalize)
+Next: Submit PR following standard process (validation → user approval → push → submit PR → finalize)
 
 ---
 

--- a/docs/project/final/version-string-management.md
+++ b/docs/project/final/version-string-management.md
@@ -1,0 +1,124 @@
+# Version string management
+
+Define how MNEMOSYS Core assigns and maintains version strings for all deployed
+artifacts and environments.
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Invariants](#invariants)
+- [Version format](#version-format)
+- [Source of truth](#source-of-truth)
+- [Increment rules](#increment-rules)
+- [Pull request preparation tool](#pull-request-preparation-tool)
+- [Develop merge workflow](#develop-merge-workflow)
+- [Release workflow](#release-workflow)
+- [Main promotion workflow](#main-promotion-workflow)
+- [Validation and failure modes](#validation-and-failure-modes)
+
+## Purpose
+Ensure every deployed artifact has a unique, human-readable version identifier
+that is stable, auditable, and compatible with release governance.
+
+## Invariants
+- Every deployed artifact in any environment maps to a unique version string.
+- The rightmost component (`BUILD`) auto-increments on every merge to `develop`.
+- `PATCH` increments when a `develop` to `release` PR is opened.
+- Major and minor changes are explicit human decisions.
+- Version numbers are never reused or mutated after deployment.
+- The format is simple, explicit, and does not rely on implicit state.
+
+## Version format
+Use a four-part numeric version string:
+
+```
+MAJOR.MINOR.PATCH.BUILD
+```
+
+Rules:
+- Each component is a non-negative integer with no leading zeros (except `0`).
+- `BUILD` is the rightmost component and is auto-incremented.
+- No suffixes or build metadata are used in this repository version string.
+
+## Source of truth
+- The canonical version string lives in `pyproject.toml` under
+  `tool.poetry.version`.
+- All other references must derive from this value; do not duplicate the string
+  in code.
+- Runtime reads should use package metadata (for example,
+  `importlib.metadata.version("mnemosys-core")`) rather than hard-coded values.
+
+## Increment rules
+- `BUILD` increments by exactly 1 on every merge to `develop`.
+- `PATCH` increments by exactly 1 when a `develop` to `release` PR is opened and
+  resets `BUILD` to `0`.
+- `MAJOR` and `MINOR` are updated manually and reset `PATCH` and `BUILD` to `0`.
+- Version changes must be part of the merge PR; direct commits to `develop` are
+  forbidden.
+- If `develop` advances before merge, rebase and reapply the next `BUILD` value
+  to avoid collisions.
+
+## Pull request preparation tool
+Use the canonical script to prepare feature PRs into `develop`:
+
+```
+python scripts/dev/submit_develop_pr.py
+```
+
+The script:
+- Verifies a clean working tree and a non-eternal feature branch.
+- Ensures the branch is based on current `develop`.
+- Bumps `BUILD` to `develop` + 1, commits the bump, and runs validation.
+- Pushes the branch and opens the pull request via `gh`.
+- Applies the docs-only exception only when the changes are documentation plus
+  the version bump in `pyproject.toml`.
+
+If the script is unavailable, replicate its checks manually and ensure the
+version bump matches the current `develop` build.
+
+## Develop merge workflow
+1. Determine the current `develop` version from `pyproject.toml`.
+2. Increment `BUILD` by 1 in the PR branch (use
+   `python scripts/dev/submit_develop_pr.py`).
+3. Ensure the version bump is included in the merge PR to `develop`.
+4. If `develop` advances before merge, rebase and bump `BUILD` again.
+
+This policy requires automation or discipline to avoid skipped or duplicate
+build numbers; the CI gate must enforce the rule.
+The PR author (human or AI) owns the bump; CI must reject missing increments.
+
+## Release workflow
+1. Open a PR from `develop` to `release` using the current `develop` commit.
+2. Immediately open a separate PR to `develop` that increments `PATCH` by 1 and
+   resets `BUILD` to `0`.
+3. Merge the `develop` to `release` PR after validation.
+4. Merge the `PATCH` bump PR to `develop` before the next feature merge.
+
+If automation exists (for example, a `submit_release_prs` script), it must
+open the two PRs above without direct commits to `develop`.
+Release coordination is a developer responsibility and is enforced by CI
+gates or release checklists.
+
+Canonical command:
+
+```
+python scripts/dev/submit_release_prs.py
+```
+
+## Main promotion workflow
+1. Open a PR from `release` to `main` after validation in `release`.
+2. The PR contains no version changes; it promotes the already-versioned
+   release.
+
+Canonical command:
+
+```
+python scripts/dev/submit_main_pr.py
+```
+
+## Validation and failure modes
+CI must fail when:
+- The version string does not match `MAJOR.MINOR.PATCH.BUILD`.
+- `BUILD` is not exactly one higher than the current `develop` value for merge
+  PRs to `develop`.
+- `PATCH` bump PRs do not reset `BUILD` to `0`.
+- A version number is reused or regresses.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "mnemosys-core"
-version = "0.1.0"
+version = "0.1.0.1"
 description = "Core backend for the MNEMOSYS system"
 authors = ["Phillip Moore <w.phillip.moore@gmail.com>"]
 license = "LICENSE"

--- a/scripts/dev/submit_develop_pr.py
+++ b/scripts/dev/submit_develop_pr.py
@@ -325,9 +325,9 @@ def determine_documentation_only(changed_files: list[str], base_reference: str) 
     remaining_files = [path for path in changed_files if path != "pyproject.toml"]
     if not all(is_documentation_path(path) for path in remaining_files):
         return False
-    if "pyproject.toml" in changed_files and not pyproject_only_version_change(base_reference):
-        return False
-    return True
+    return not (
+        "pyproject.toml" in changed_files and not pyproject_only_version_change(base_reference)
+    )
 
 
 def build_default_title(base_reference: str, current_branch: str) -> str:

--- a/scripts/dev/submit_develop_pr.py
+++ b/scripts/dev/submit_develop_pr.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""
+Prepare a pull request by enforcing version bumps and pre-submission checks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+VERSION_PATTERN = re.compile(
+    r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"
+)
+
+DOCUMENTATION_ONLY_FILENAMES = {"README.md", "CHANGELOG.md"}
+FORBIDDEN_BRANCHES = {"develop", "main", "release"}
+
+
+@dataclass(frozen=True)
+class Version:
+    """Semantic version with build component."""
+
+    major: int
+    minor: int
+    patch: int
+    build: int
+
+    def as_string(self) -> str:
+        """Return the version formatted as MAJOR.MINOR.PATCH.BUILD."""
+        return f"{self.major}.{self.minor}.{self.patch}.{self.build}"
+
+
+def parse_arguments(argument_list: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Prepare a pull request by bumping BUILD, validating, pushing, "
+            "and creating the PR."
+        )
+    )
+    parser.add_argument(
+        "--base",
+        default="develop",
+        help="Target base branch for the pull request.",
+    )
+    parser.add_argument(
+        "--remote",
+        default="origin",
+        help="Git remote used for fetch and push.",
+    )
+    parser.add_argument(
+        "--title",
+        default=None,
+        help="Optional pull request title. Defaults to commit history or branch name.",
+    )
+    parser.add_argument(
+        "--body",
+        default=None,
+        help="Optional pull request body. Use for single-line bodies.",
+    )
+    parser.add_argument(
+        "--body-file",
+        dest="body_file",
+        default=None,
+        help="Optional path to a pull request body file.",
+    )
+    parser.add_argument(
+        "--draft",
+        action="store_true",
+        help="Create the pull request as a draft.",
+    )
+    parser.add_argument(
+        "--force-validation",
+        action="store_true",
+        help="Run validation even when changes are docs-only.",
+    )
+    parser.add_argument(
+        "--no-fetch",
+        action="store_true",
+        help="Skip fetching the base branch from the remote.",
+    )
+    return parser.parse_args(list(argument_list) if argument_list is not None else None)
+
+
+def ensure_project_root() -> None:
+    """Fail fast if invoked outside the repository root."""
+    if not Path("pyproject.toml").is_file():
+        raise SystemExit("Run from the repository root (pyproject.toml missing).")
+
+
+def ensure_executable_available(executable: str) -> None:
+    """Ensure a required executable is available."""
+    if shutil.which(executable) is None:
+        raise SystemExit(f"Required executable not found on PATH: {executable}")
+
+
+def run_command(command: Sequence[str], check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run a command and return the completed process."""
+    return subprocess.run(command, check=check)
+
+
+def read_command_output(command: Sequence[str]) -> str:
+    """Run a command and return its stripped standard output."""
+    result = subprocess.run(command, check=True, text=True, capture_output=True)
+    return result.stdout.strip()
+
+
+def ensure_clean_worktree() -> None:
+    """Ensure there are no uncommitted changes."""
+    status_output = read_command_output(("git", "status", "--porcelain"))
+    if status_output:
+        raise SystemExit("Working tree must be clean before preparing a pull request.")
+
+
+def get_current_branch() -> str:
+    """Return the current git branch name."""
+    return read_command_output(("git", "rev-parse", "--abbrev-ref", "HEAD"))
+
+
+def ensure_branch_allowed(current_branch: str, base_branch: str) -> None:
+    """Prevent preparing pull requests from forbidden branches."""
+    forbidden = FORBIDDEN_BRANCHES | {base_branch}
+    if current_branch in forbidden:
+        raise SystemExit(f"Refuse to run on branch '{current_branch}'.")
+
+
+def ensure_base_branch_supported(base_branch: str) -> None:
+    """Ensure the tool is only used for develop-bound pull requests."""
+    if base_branch != "develop":
+        raise SystemExit("submit_develop_pr supports only develop-bound pull requests.")
+
+
+def list_open_pull_requests(base_branch: str) -> list[dict[str, object]]:
+    """Return open pull requests that target the base branch."""
+    output = read_command_output(
+        (
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--base",
+            base_branch,
+            "--json",
+            "number,title,headRefName",
+        )
+    )
+    try:
+        data = json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise SystemExit("Unable to parse gh pr list output.") from exc
+    if not isinstance(data, list):
+        raise SystemExit("Unexpected gh pr list output format.")
+    return data
+
+
+def ensure_no_open_pull_requests(base_branch: str) -> None:
+    """Fail if open pull requests already target the base branch."""
+    pull_requests = list_open_pull_requests(base_branch)
+    if not pull_requests:
+        return
+    details = []
+    for pull_request in pull_requests:
+        number = pull_request.get("number")
+        title = pull_request.get("title")
+        head_reference_name = pull_request.get("headRefName")
+        details.append(f"#{number} {head_reference_name}: {title}")
+    details_text = "\n".join(details)
+    raise SystemExit(f"Open pull requests already target {base_branch}:\n{details_text}")
+
+
+def git_reference_exists(reference: str) -> bool:
+    """Return True if the git reference exists."""
+    result = subprocess.run(("git", "rev-parse", "--verify", "--quiet", reference))
+    return result.returncode == 0
+
+
+def fetch_base_branch(remote_name: str, base_branch: str) -> None:
+    """Fetch the base branch from the remote."""
+    run_command(("git", "fetch", remote_name, base_branch))
+
+
+def resolve_base_reference(remote_name: str, base_branch: str) -> str:
+    """Resolve the base reference preferring the remote tracking branch."""
+    remote_reference = f"{remote_name}/{base_branch}"
+    if git_reference_exists(remote_reference):
+        return remote_reference
+    if git_reference_exists(base_branch):
+        return base_branch
+    raise SystemExit(f"Unable to resolve base branch reference for '{base_branch}'.")
+
+
+def ensure_branch_divergence(base_reference: str) -> None:
+    """Ensure the feature branch is ahead of and not behind the base."""
+    behind_count = int(read_command_output(("git", "rev-list", "--count", f"HEAD..{base_reference}")))
+    if behind_count > 0:
+        raise SystemExit("Branch is behind base; rebase before preparing a pull request.")
+
+    ahead_count = int(read_command_output(("git", "rev-list", "--count", f"{base_reference}..HEAD")))
+    if ahead_count == 0:
+        raise SystemExit("No commits found relative to base; nothing to submit.")
+
+
+def load_version_from_toml_text(toml_text: str) -> Version:
+    """Load the version from a pyproject.toml text block."""
+    data = tomllib.loads(toml_text)
+    try:
+        version_value = data["tool"]["poetry"]["version"]
+    except KeyError as exc:
+        raise SystemExit("Missing tool.poetry.version in pyproject.toml.") from exc
+    if not isinstance(version_value, str):
+        raise SystemExit("tool.poetry.version must be a string.")
+    return parse_version(version_value)
+
+
+def load_current_version() -> Version:
+    """Load the version from the working tree."""
+    pyproject_text = Path("pyproject.toml").read_text()
+    return load_version_from_toml_text(pyproject_text)
+
+
+def load_base_version(base_reference: str) -> Version:
+    """Load the version from the base branch."""
+    pyproject_text = read_command_output(("git", "show", f"{base_reference}:pyproject.toml"))
+    return load_version_from_toml_text(pyproject_text)
+
+
+def parse_version(version_value: str) -> Version:
+    """Parse and validate a version string."""
+    match = VERSION_PATTERN.match(version_value)
+    if not match:
+        raise SystemExit(f"Invalid version format: {version_value}")
+    major, minor, patch, build = (int(part) for part in match.groups())
+    return Version(major=major, minor=minor, patch=patch, build=build)
+
+
+def determine_build_bump(base_version: Version, current_version: Version) -> Version | None:
+    """Return the next build version, or None if already bumped."""
+    if (base_version.major, base_version.minor, base_version.patch) != (
+        current_version.major,
+        current_version.minor,
+        current_version.patch,
+    ):
+        raise SystemExit("Major, minor, and patch must match base. Use the release workflow to change them.")
+
+    if current_version.build == base_version.build:
+        return Version(
+            major=current_version.major,
+            minor=current_version.minor,
+            patch=current_version.patch,
+            build=current_version.build + 1,
+        )
+    if current_version.build == base_version.build + 1:
+        return None
+
+    raise SystemExit("Build number must be base BUILD or base BUILD + 1.")
+
+
+def update_pyproject_version(current_version: Version, new_version: Version) -> None:
+    """Update the version string in pyproject.toml."""
+    pyproject_path = Path("pyproject.toml")
+    content = pyproject_path.read_text()
+    version_pattern = re.compile(r'^(version\s*=\s*")([^"]+)(")\s*$', re.MULTILINE)
+    matches = list(version_pattern.finditer(content))
+    if len(matches) != 1:
+        raise SystemExit("Expected a single version entry in pyproject.toml.")
+
+    match = matches[0]
+    existing_version = match.group(2)
+    if existing_version != current_version.as_string():
+        raise SystemExit("pyproject.toml version does not match expected value.")
+
+    updated = content[: match.start(2)] + new_version.as_string() + content[match.end(2) :]
+    pyproject_path.write_text(updated)
+
+
+def commit_version_bump(new_version: Version) -> None:
+    """Commit the version bump."""
+    run_command(("git", "add", "pyproject.toml"))
+    commit_message = f"chore: bump build version to {new_version.as_string()}"
+    run_command(("git", "commit", "-m", commit_message))
+
+
+def collect_changed_files(base_reference: str) -> list[str]:
+    """Collect changed files relative to the base reference."""
+    output = read_command_output(("git", "diff", "--name-only", f"{base_reference}...HEAD"))
+    return [line for line in output.splitlines() if line]
+
+
+def is_documentation_path(file_path: str) -> bool:
+    """Return True if the file path counts as documentation."""
+    if file_path in DOCUMENTATION_ONLY_FILENAMES:
+        return True
+    return Path(file_path).parts[:1] == ("docs",)
+
+
+def pyproject_only_version_change(base_reference: str) -> bool:
+    """Return True if pyproject.toml changes only the version."""
+    base_text = read_command_output(("git", "show", f"{base_reference}:pyproject.toml"))
+    current_text = Path("pyproject.toml").read_text()
+    base_data = tomllib.loads(base_text)
+    current_data = tomllib.loads(current_text)
+    try:
+        current_version = current_data["tool"]["poetry"]["version"]
+    except KeyError as exc:
+        raise SystemExit("Missing tool.poetry.version in current pyproject.toml.") from exc
+    base_data["tool"]["poetry"]["version"] = current_version
+    return base_data == current_data
+
+
+def determine_documentation_only(changed_files: list[str], base_reference: str) -> bool:
+    """Return True if changes are documentation-only plus a version bump."""
+    remaining_files = [path for path in changed_files if path != "pyproject.toml"]
+    if not all(is_documentation_path(path) for path in remaining_files):
+        return False
+    if "pyproject.toml" in changed_files and not pyproject_only_version_change(base_reference):
+        return False
+    return True
+
+
+def build_default_title(base_reference: str, current_branch: str) -> str:
+    """Derive a default pull request title."""
+    commit_messages = read_command_output(("git", "log", "--format=%s", f"{base_reference}..HEAD"))
+    for message in commit_messages.splitlines():
+        if not message.startswith("chore: bump build version to"):
+            return message
+    return current_branch.replace("-", " ")
+
+
+def build_documentation_only_body(changed_files: list[str], existing_body: str | None) -> str:
+    """Build a documentation-only pull request body with required annotations."""
+    lines: list[str] = []
+    if existing_body:
+        lines.append(existing_body.strip())
+        lines.append("")
+    lines.append("Docs-only: tests skipped")
+    lines.append("")
+    lines.append("Files changed:")
+    for file_path in sorted(changed_files):
+        lines.append(f"- {file_path}")
+    return "\n".join(lines).strip() + "\n"
+
+
+def run_validation() -> None:
+    """Run the canonical local validation."""
+    result = run_command((sys.executable, "scripts/dev/validate_local.py"), check=False)
+    if result.returncode != 0:
+        raise SystemExit(result.returncode)
+
+
+def create_pull_request(
+    arguments: argparse.Namespace,
+    base_reference: str,
+    changed_files: list[str],
+    current_branch: str,
+    documentation_only: bool,
+) -> None:
+    """Push the branch and create the pull request."""
+    run_command(("git", "push", "--set-upstream", arguments.remote, "HEAD"))
+
+    command = ["gh", "pr", "create", "--base", arguments.base, "--head", current_branch]
+    if arguments.draft:
+        command.append("--draft")
+
+    temporary_body_path = None
+    if documentation_only:
+        title = arguments.title or build_default_title(base_reference, current_branch)
+        command.extend(["--title", title])
+        existing_body = None
+        if arguments.body_file:
+            existing_body = Path(arguments.body_file).read_text()
+        elif arguments.body:
+            existing_body = arguments.body
+        body_text = build_documentation_only_body(changed_files, existing_body)
+        with tempfile.NamedTemporaryFile("w", delete=False) as temporary_body:
+            temporary_body.write(body_text)
+            temporary_body_path = temporary_body.name
+        command.extend(["--body-file", temporary_body_path])
+    else:
+        if arguments.title:
+            command.extend(["--title", arguments.title])
+        if arguments.body_file:
+            command.extend(["--body-file", arguments.body_file])
+        elif arguments.body is not None:
+            command.extend(["--body", arguments.body])
+        elif not arguments.title:
+            command.append("--fill")
+        elif arguments.body is None and arguments.body_file is None:
+            command.extend(["--body", ""])
+
+    try:
+        run_command(tuple(command))
+    finally:
+        if documentation_only and temporary_body_path is not None:
+            Path(temporary_body_path).unlink(missing_ok=True)
+
+
+def main(argument_list: Sequence[str] | None = None) -> int:
+    """Entry point for preparing a pull request."""
+    arguments = parse_arguments(argument_list)
+
+    ensure_project_root()
+    ensure_executable_available("git")
+    ensure_executable_available("gh")
+    ensure_clean_worktree()
+    ensure_base_branch_supported(arguments.base)
+    ensure_no_open_pull_requests(arguments.base)
+
+    if not arguments.no_fetch:
+        fetch_base_branch(arguments.remote, arguments.base)
+
+    base_reference = resolve_base_reference(arguments.remote, arguments.base)
+    current_branch = get_current_branch()
+    ensure_branch_allowed(current_branch, arguments.base)
+    ensure_branch_divergence(base_reference)
+
+    base_version = load_base_version(base_reference)
+    current_version = load_current_version()
+    new_version = determine_build_bump(base_version, current_version)
+    if new_version is not None:
+        update_pyproject_version(current_version, new_version)
+        commit_version_bump(new_version)
+
+    changed_files = collect_changed_files(base_reference)
+    documentation_only = determine_documentation_only(changed_files, base_reference)
+    if not documentation_only or arguments.force_validation:
+        run_validation()
+
+    create_pull_request(arguments, base_reference, changed_files, current_branch, documentation_only)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/submit_main_pr.py
+++ b/scripts/dev/submit_main_pr.py
@@ -10,10 +10,9 @@ import json
 import shutil
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 from typing import TYPE_CHECKING
-
-import tomllib
 
 if TYPE_CHECKING:
     from collections.abc import Sequence

--- a/scripts/dev/submit_main_pr.py
+++ b/scripts/dev/submit_main_pr.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""
+Create a release->main pull request with validation and guardrails.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import tomllib
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def parse_arguments(argument_list: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Create a release->main pull request.")
+    parser.add_argument(
+        "--remote",
+        default="origin",
+        help="Git remote used for fetch.",
+    )
+    parser.add_argument(
+        "--release-branch",
+        default="release",
+        help="Branch used for release promotion.",
+    )
+    parser.add_argument(
+        "--main-branch",
+        default="main",
+        help="Branch used for production promotion.",
+    )
+    parser.add_argument(
+        "--title",
+        default=None,
+        help="Optional pull request title.",
+    )
+    parser.add_argument(
+        "--body",
+        default=None,
+        help="Optional pull request body. Use for single-line bodies.",
+    )
+    parser.add_argument(
+        "--body-file",
+        dest="body_file",
+        default=None,
+        help="Optional path to a pull request body file.",
+    )
+    parser.add_argument(
+        "--draft",
+        action="store_true",
+        help="Create the pull request as a draft.",
+    )
+    parser.add_argument(
+        "--no-fetch",
+        action="store_true",
+        help="Skip fetching the release and main branches from the remote.",
+    )
+    return parser.parse_args(list(argument_list) if argument_list is not None else None)
+
+
+def ensure_project_root() -> None:
+    """Fail fast if invoked outside the repository root."""
+    if not Path("pyproject.toml").is_file():
+        raise SystemExit("Run from the repository root (pyproject.toml missing).")
+
+
+def ensure_executable_available(executable: str) -> None:
+    """Ensure a required executable is available."""
+    if shutil.which(executable) is None:
+        raise SystemExit(f"Required executable not found on PATH: {executable}")
+
+
+def run_command(command: Sequence[str], check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run a command and return the completed process."""
+    return subprocess.run(command, check=check)
+
+
+def read_command_output(command: Sequence[str]) -> str:
+    """Run a command and return its stripped standard output."""
+    result = subprocess.run(command, check=True, text=True, capture_output=True)
+    return result.stdout.strip()
+
+
+def ensure_clean_worktree() -> None:
+    """Ensure there are no uncommitted changes."""
+    status_output = read_command_output(("git", "status", "--porcelain"))
+    if status_output:
+        raise SystemExit("Working tree must be clean before preparing releases.")
+
+
+def get_current_branch() -> str:
+    """Return the current git branch name."""
+    return read_command_output(("git", "rev-parse", "--abbrev-ref", "HEAD"))
+
+
+def ensure_on_branch(current_branch: str, expected_branch: str) -> None:
+    """Ensure the current branch matches expectations."""
+    if current_branch != expected_branch:
+        raise SystemExit(f"Switch to '{expected_branch}' before running this script.")
+
+
+def fetch_branches(remote_name: str, release_branch: str, main_branch: str) -> None:
+    """Fetch the release and main branches from the remote."""
+    run_command(("git", "fetch", remote_name, release_branch))
+    run_command(("git", "fetch", remote_name, main_branch))
+
+
+def ensure_branch_matches_remote(remote_name: str, branch_name: str) -> None:
+    """Ensure the local branch matches the remote tracking branch."""
+    remote_reference = f"{remote_name}/{branch_name}"
+    local_commit = read_command_output(("git", "rev-parse", branch_name))
+    remote_commit = read_command_output(("git", "rev-parse", remote_reference))
+    if local_commit != remote_commit:
+        raise SystemExit(f"{branch_name} must match {remote_reference} before promoting.")
+
+
+def list_open_pull_requests(base_branch: str) -> list[dict[str, object]]:
+    """Return open pull requests that target the base branch."""
+    output = read_command_output(
+        (
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--base",
+            base_branch,
+            "--json",
+            "number,title,headRefName",
+        )
+    )
+    try:
+        data = json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise SystemExit("Unable to parse gh pr list output.") from exc
+    if not isinstance(data, list):
+        raise SystemExit("Unexpected gh pr list output format.")
+    return data
+
+
+def ensure_no_open_pull_requests(base_branch: str) -> None:
+    """Fail if open pull requests already target the base branch."""
+    pull_requests = list_open_pull_requests(base_branch)
+    if not pull_requests:
+        return
+    details = []
+    for pull_request in pull_requests:
+        number = pull_request.get("number")
+        title = pull_request.get("title")
+        head_reference_name = pull_request.get("headRefName")
+        details.append(f"#{number} {head_reference_name}: {title}")
+    details_text = "\n".join(details)
+    raise SystemExit(f"Open pull requests already target {base_branch}:\n{details_text}")
+
+
+def load_version_label() -> str:
+    """Load the version string for display."""
+    data = tomllib.loads(Path("pyproject.toml").read_text())
+    try:
+        version_value = data["tool"]["poetry"]["version"]
+    except KeyError as exc:
+        raise SystemExit("Missing tool.poetry.version in pyproject.toml.") from exc
+    if not isinstance(version_value, str):
+        raise SystemExit("tool.poetry.version must be a string.")
+    return version_value
+
+
+def run_validation() -> None:
+    """Run the canonical local validation."""
+    result = run_command((sys.executable, "scripts/dev/validate_local.py"), check=False)
+    if result.returncode != 0:
+        raise SystemExit(result.returncode)
+
+
+def create_pull_request(arguments: argparse.Namespace, release_branch: str, main_branch: str) -> None:
+    """Create the release->main pull request."""
+    command = ["gh", "pr", "create", "--base", main_branch, "--head", release_branch]
+    if arguments.draft:
+        command.append("--draft")
+
+    if arguments.title:
+        command.extend(["--title", arguments.title])
+    else:
+        version_label = load_version_label()
+        command.extend(["--title", f"Promote release {version_label}"])
+
+    if arguments.body_file:
+        command.extend(["--body-file", arguments.body_file])
+    elif arguments.body is not None:
+        command.extend(["--body", arguments.body])
+    else:
+        command.extend(["--body", ""])
+
+    run_command(tuple(command))
+
+
+def main(argument_list: Sequence[str] | None = None) -> int:
+    """Entry point for creating a release->main pull request."""
+    arguments = parse_arguments(argument_list)
+
+    ensure_project_root()
+    ensure_executable_available("git")
+    ensure_executable_available("gh")
+    ensure_clean_worktree()
+
+    if not arguments.no_fetch:
+        fetch_branches(arguments.remote, arguments.release_branch, arguments.main_branch)
+
+    current_branch = get_current_branch()
+    ensure_on_branch(current_branch, arguments.release_branch)
+    ensure_branch_matches_remote(arguments.remote, arguments.release_branch)
+    ensure_no_open_pull_requests(arguments.main_branch)
+
+    run_validation()
+    create_pull_request(arguments, arguments.release_branch, arguments.main_branch)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/submit_release_prs.py
+++ b/scripts/dev/submit_release_prs.py
@@ -11,12 +11,11 @@ import re
 import shutil
 import subprocess
 import sys
+import tomllib
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
-
-import tomllib
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -276,7 +275,7 @@ def commit_patch_bump(new_version: Version) -> None:
 
 def create_patch_branch_name(version: Version) -> str:
     """Generate a unique patch branch name."""
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+    timestamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
     return f"feature/patch-bump-{version.as_branch_label()}-{timestamp}"
 
 

--- a/scripts/dev/submit_release_prs.py
+++ b/scripts/dev/submit_release_prs.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""
+Create release and patch-bump pull requests from develop.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import tomllib
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+VERSION_PATTERN = re.compile(
+    r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"
+)
+
+
+@dataclass(frozen=True)
+class Version:
+    """Semantic version with build component."""
+
+    major: int
+    minor: int
+    patch: int
+    build: int
+
+    def as_string(self) -> str:
+        """Return the version formatted as MAJOR.MINOR.PATCH.BUILD."""
+        return f"{self.major}.{self.minor}.{self.patch}.{self.build}"
+
+    def as_branch_label(self) -> str:
+        """Return the version formatted for use in branch names."""
+        return self.as_string().replace(".", "-")
+
+
+def parse_arguments(argument_list: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create a develop->release PR and a patch-bump PR to develop. "
+            "The patch bump increments PATCH and resets BUILD to 0."
+        )
+    )
+    parser.add_argument(
+        "--remote",
+        default="origin",
+        help="Git remote used for fetch and push.",
+    )
+    parser.add_argument(
+        "--develop-branch",
+        default="develop",
+        help="Branch used as the source for releases.",
+    )
+    parser.add_argument(
+        "--release-branch",
+        default="release",
+        help="Branch used for release promotion.",
+    )
+    parser.add_argument(
+        "--patch-branch-name",
+        default=None,
+        help="Explicit branch name for the patch bump PR.",
+    )
+    parser.add_argument(
+        "--release-title",
+        default=None,
+        help="Optional title for the release pull request.",
+    )
+    parser.add_argument(
+        "--release-body",
+        default=None,
+        help="Optional body for the release pull request.",
+    )
+    parser.add_argument(
+        "--release-body-file",
+        dest="release_body_file",
+        default=None,
+        help="Optional body file for the release pull request.",
+    )
+    parser.add_argument(
+        "--patch-title",
+        default=None,
+        help="Optional title for the patch bump pull request.",
+    )
+    parser.add_argument(
+        "--patch-body",
+        default=None,
+        help="Optional body for the patch bump pull request.",
+    )
+    parser.add_argument(
+        "--patch-body-file",
+        dest="patch_body_file",
+        default=None,
+        help="Optional body file for the patch bump pull request.",
+    )
+    parser.add_argument(
+        "--draft",
+        action="store_true",
+        help="Create both pull requests as drafts.",
+    )
+    parser.add_argument(
+        "--no-fetch",
+        action="store_true",
+        help="Skip fetching the develop and release branches from the remote.",
+    )
+    return parser.parse_args(list(argument_list) if argument_list is not None else None)
+
+
+def ensure_project_root() -> None:
+    """Fail fast if invoked outside the repository root."""
+    if not Path("pyproject.toml").is_file():
+        raise SystemExit("Run from the repository root (pyproject.toml missing).")
+
+
+def ensure_executable_available(executable: str) -> None:
+    """Ensure a required executable is available."""
+    if shutil.which(executable) is None:
+        raise SystemExit(f"Required executable not found on PATH: {executable}")
+
+
+def run_command(command: Sequence[str], check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run a command and return the completed process."""
+    return subprocess.run(command, check=check)
+
+
+def read_command_output(command: Sequence[str]) -> str:
+    """Run a command and return its stripped standard output."""
+    result = subprocess.run(command, check=True, text=True, capture_output=True)
+    return result.stdout.strip()
+
+
+def ensure_clean_worktree() -> None:
+    """Ensure there are no uncommitted changes."""
+    status_output = read_command_output(("git", "status", "--porcelain"))
+    if status_output:
+        raise SystemExit("Working tree must be clean before preparing releases.")
+
+
+def get_current_branch() -> str:
+    """Return the current git branch name."""
+    return read_command_output(("git", "rev-parse", "--abbrev-ref", "HEAD"))
+
+
+def ensure_on_develop(current_branch: str, develop_branch: str) -> None:
+    """Ensure the current branch is the develop branch."""
+    if current_branch != develop_branch:
+        raise SystemExit(f"Switch to '{develop_branch}' before running this script.")
+
+
+def list_open_pull_requests(base_branch: str) -> list[dict[str, object]]:
+    """Return open pull requests that target the base branch."""
+    output = read_command_output(
+        (
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--base",
+            base_branch,
+            "--json",
+            "number,title,headRefName",
+        )
+    )
+    try:
+        data = json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise SystemExit("Unable to parse gh pr list output.") from exc
+    if not isinstance(data, list):
+        raise SystemExit("Unexpected gh pr list output format.")
+    return data
+
+
+def ensure_no_open_pull_requests(base_branch: str) -> None:
+    """Fail if open pull requests already target the base branch."""
+    pull_requests = list_open_pull_requests(base_branch)
+    if not pull_requests:
+        return
+    details = []
+    for pull_request in pull_requests:
+        number = pull_request.get("number")
+        title = pull_request.get("title")
+        head_reference_name = pull_request.get("headRefName")
+        details.append(f"#{number} {head_reference_name}: {title}")
+    details_text = "\n".join(details)
+    raise SystemExit(f"Open pull requests already target {base_branch}:\n{details_text}")
+
+
+def fetch_branches(remote_name: str, develop_branch: str, release_branch: str) -> None:
+    """Fetch the develop and release branches from the remote."""
+    run_command(("git", "fetch", remote_name, develop_branch))
+    run_command(("git", "fetch", remote_name, release_branch))
+
+
+def ensure_branch_matches_remote(remote_name: str, branch_name: str) -> None:
+    """Ensure the local branch matches the remote tracking branch."""
+    remote_reference = f"{remote_name}/{branch_name}"
+    local_commit = read_command_output(("git", "rev-parse", branch_name))
+    remote_commit = read_command_output(("git", "rev-parse", remote_reference))
+    if local_commit != remote_commit:
+        raise SystemExit(f"{branch_name} must match {remote_reference} before releasing.")
+
+
+def parse_version(version_value: str) -> Version:
+    """Parse and validate a version string."""
+    match = VERSION_PATTERN.match(version_value)
+    if not match:
+        raise SystemExit(f"Invalid version format: {version_value}")
+    major, minor, patch, build = (int(part) for part in match.groups())
+    return Version(major=major, minor=minor, patch=patch, build=build)
+
+
+def load_version_from_toml_text(toml_text: str) -> Version:
+    """Load the version from a pyproject.toml text block."""
+    data = tomllib.loads(toml_text)
+    try:
+        version_value = data["tool"]["poetry"]["version"]
+    except KeyError as exc:
+        raise SystemExit("Missing tool.poetry.version in pyproject.toml.") from exc
+    if not isinstance(version_value, str):
+        raise SystemExit("tool.poetry.version must be a string.")
+    return parse_version(version_value)
+
+
+def load_develop_version(develop_branch: str) -> Version:
+    """Load the version from the develop branch."""
+    pyproject_text = read_command_output(("git", "show", f"{develop_branch}:pyproject.toml"))
+    return load_version_from_toml_text(pyproject_text)
+
+
+def bump_patch_version(version: Version) -> Version:
+    """Return the next patch version with build reset."""
+    return Version(
+        major=version.major,
+        minor=version.minor,
+        patch=version.patch + 1,
+        build=0,
+    )
+
+
+def update_pyproject_version(current_version: Version, new_version: Version) -> None:
+    """Update the version string in pyproject.toml."""
+    pyproject_path = Path("pyproject.toml")
+    content = pyproject_path.read_text()
+    version_pattern = re.compile(r'^(version\s*=\s*")([^"]+)(")\s*$', re.MULTILINE)
+    matches = list(version_pattern.finditer(content))
+    if len(matches) != 1:
+        raise SystemExit("Expected a single version entry in pyproject.toml.")
+
+    match = matches[0]
+    existing_version = match.group(2)
+    if existing_version != current_version.as_string():
+        raise SystemExit("pyproject.toml version does not match expected value.")
+
+    updated = content[: match.start(2)] + new_version.as_string() + content[match.end(2) :]
+    pyproject_path.write_text(updated)
+
+
+def commit_patch_bump(new_version: Version) -> None:
+    """Commit the patch bump."""
+    run_command(("git", "add", "pyproject.toml"))
+    commit_message = f"chore: bump patch version to {new_version.as_string()}"
+    run_command(("git", "commit", "-m", commit_message))
+
+
+def create_patch_branch_name(version: Version) -> str:
+    """Generate a unique patch branch name."""
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+    return f"feature/patch-bump-{version.as_branch_label()}-{timestamp}"
+
+
+def ensure_branch_available(branch_name: str) -> None:
+    """Ensure the branch name is not already in use."""
+    result = subprocess.run(("git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch_name}"))
+    if result.returncode == 0:
+        raise SystemExit(f"Branch already exists: {branch_name}")
+
+
+def run_validation() -> None:
+    """Run the canonical local validation."""
+    result = run_command((sys.executable, "scripts/dev/validate_local.py"), check=False)
+    if result.returncode != 0:
+        raise SystemExit(result.returncode)
+
+
+def create_release_pull_request(
+    develop_branch: str,
+    release_branch: str,
+    release_version: Version,
+    arguments: argparse.Namespace,
+) -> None:
+    """Create the develop->release pull request."""
+    command = [
+        "gh",
+        "pr",
+        "create",
+        "--base",
+        release_branch,
+        "--head",
+        develop_branch,
+    ]
+    if arguments.draft:
+        command.append("--draft")
+    title = arguments.release_title or f"Release {release_version.as_string()}"
+    command.extend(["--title", title])
+    if arguments.release_body_file:
+        command.extend(["--body-file", arguments.release_body_file])
+    elif arguments.release_body is not None:
+        command.extend(["--body", arguments.release_body])
+    else:
+        command.extend(["--body", ""])
+    run_command(tuple(command))
+
+
+def create_patch_pull_request(
+    patch_branch_name: str,
+    develop_branch: str,
+    patch_version: Version,
+    arguments: argparse.Namespace,
+) -> None:
+    """Create the patch bump pull request."""
+    command = [
+        "gh",
+        "pr",
+        "create",
+        "--base",
+        develop_branch,
+        "--head",
+        patch_branch_name,
+    ]
+    if arguments.draft:
+        command.append("--draft")
+    title = arguments.patch_title or f"chore: bump patch version to {patch_version.as_string()}"
+    command.extend(["--title", title])
+    if arguments.patch_body_file:
+        command.extend(["--body-file", arguments.patch_body_file])
+    elif arguments.patch_body is not None:
+        command.extend(["--body", arguments.patch_body])
+    else:
+        command.extend(["--body", ""])
+    run_command(tuple(command))
+
+
+def main(argument_list: Sequence[str] | None = None) -> int:
+    """Entry point for creating release pull requests."""
+    arguments = parse_arguments(argument_list)
+
+    ensure_project_root()
+    ensure_executable_available("git")
+    ensure_executable_available("gh")
+    ensure_clean_worktree()
+
+    if not arguments.no_fetch:
+        fetch_branches(arguments.remote, arguments.develop_branch, arguments.release_branch)
+
+    current_branch = get_current_branch()
+    ensure_on_develop(current_branch, arguments.develop_branch)
+    ensure_branch_matches_remote(arguments.remote, arguments.develop_branch)
+    ensure_no_open_pull_requests(arguments.release_branch)
+    ensure_no_open_pull_requests(arguments.develop_branch)
+
+    develop_version = load_develop_version(arguments.develop_branch)
+    patch_version = bump_patch_version(develop_version)
+
+    patch_branch_name = arguments.patch_branch_name or create_patch_branch_name(patch_version)
+    ensure_branch_available(patch_branch_name)
+
+    run_command(("git", "checkout", "-b", patch_branch_name))
+    update_pyproject_version(develop_version, patch_version)
+    commit_patch_bump(patch_version)
+    run_validation()
+
+    run_command(("git", "push", "--set-upstream", arguments.remote, patch_branch_name))
+    create_release_pull_request(
+        arguments.develop_branch,
+        arguments.release_branch,
+        develop_version,
+        arguments,
+    )
+    create_patch_pull_request(
+        patch_branch_name,
+        arguments.develop_branch,
+        patch_version,
+        arguments,
+    )
+
+    run_command(("git", "checkout", arguments.develop_branch))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add submit_* scripts for develop/release/main PR flows with guardrails
- document 4-part versioning workflow and update submit/finalize checkpoints
- bump package version to 0.1.0.1

## Testing
- python3 scripts/dev/validate_local.py
