### PR TITLE
chore: promotion branch prefix rules

### DIFF
--- a/docs/project/final/Development_Branching_Deployment_Model.md
+++ b/docs/project/final/Development_Branching_Deployment_Model.md
@@ -14,4 +14,9 @@ https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-m
 
 ## Local deviations
 
-None.
+- Short-lived branch prefixes allow `promotion/` in addition to
+  `feature/`, `bugfix/`, and `hotfix/`.
+- Promotion branches for environment promotions use the `promotion/` prefix
+  with these names: `promotion/release-<version>-<yyyymmddhhmmss>` for
+  develop->release and `promotion/main-<version>-<yyyymmddhhmmss>` for
+  release->main.

--- a/docs/project/final/version-string-management.md
+++ b/docs/project/final/version-string-management.md
@@ -87,11 +87,17 @@ build numbers; the CI gate must enforce the rule.
 The PR author (human or AI) owns the bump; CI must reject missing increments.
 
 ## Release workflow
-1. Open a PR from `develop` to `release` using the current `develop` commit.
-2. Immediately open a separate PR to `develop` that increments `PATCH` by 1 and
+1. Create a promotion branch from `develop` and open a PR from that branch to
+   `release`.
+2. If `release` has diverged, merge `release` into the promotion branch and
+   resolve conflicts in the promotion branch before PR merge.
+3. Immediately open a separate PR to `develop` that increments `PATCH` by 1 and
    resets `BUILD` to `0`.
-3. Merge the `develop` to `release` PR after validation.
-4. Merge the `PATCH` bump PR to `develop` before the next feature merge.
+4. Merge the promotion PR after validation using a merge commit (no squash).
+5. Merge the `PATCH` bump PR to `develop` before the next feature merge.
+
+Promotion branch naming:
+- `promotion/release-<version>-<yyyymmddhhmmss>`
 
 If automation exists (for example, a `submit_release_prs` script), it must
 open the two PRs above without direct commits to `develop`.
@@ -105,9 +111,16 @@ python scripts/dev/submit_release_prs.py
 ```
 
 ## Main promotion workflow
-1. Open a PR from `release` to `main` after validation in `release`.
-2. The PR contains no version changes; it promotes the already-versioned
+1. Create a promotion branch from `release` and open a PR from that branch to
+   `main` after validation in `release`.
+2. If `main` has diverged, merge `main` into the promotion branch and resolve
+   conflicts in the promotion branch before PR merge.
+3. Merge the promotion PR using a merge commit (no squash).
+4. The PR contains no version changes; it promotes the already-versioned
    release.
+
+Promotion branch naming:
+- `promotion/main-<version>-<yyyymmddhhmmss>`
 
 Canonical command:
 

--- a/scripts/dev/submit_main_pr.py
+++ b/scripts/dev/submit_main_pr.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Create a release->main pull request with validation and guardrails.
+Create a release->main pull request via a promotion branch.
 """
 
 from __future__ import annotations
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import sys
 import tomllib
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -20,7 +21,9 @@ if TYPE_CHECKING:
 
 def parse_arguments(argument_list: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(description="Create a release->main pull request.")
+    parser = argparse.ArgumentParser(
+        description="Create a release->main pull request via a promotion branch."
+    )
     parser.add_argument(
         "--remote",
         default="origin",
@@ -35,6 +38,11 @@ def parse_arguments(argument_list: Sequence[str] | None = None) -> argparse.Name
         "--main-branch",
         default="main",
         help="Branch used for production promotion.",
+    )
+    parser.add_argument(
+        "--promotion-branch-name",
+        default=None,
+        help="Explicit branch name for the promotion pull request.",
     )
     parser.add_argument(
         "--title",
@@ -56,6 +64,11 @@ def parse_arguments(argument_list: Sequence[str] | None = None) -> argparse.Name
         "--draft",
         action="store_true",
         help="Create the pull request as a draft.",
+    )
+    parser.add_argument(
+        "--no-target-merge",
+        action="store_true",
+        help="Skip merging the main branch into the promotion branch.",
     )
     parser.add_argument(
         "--no-fetch",
@@ -172,6 +185,31 @@ def load_version_label() -> str:
     return version_value
 
 
+def create_promotion_branch_name(version_label: str) -> str:
+    """Generate a unique promotion branch name."""
+    timestamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    sanitized_label = version_label.replace(".", "-")
+    return f"promotion/main-{sanitized_label}-{timestamp}"
+
+
+def ensure_branch_available(branch_name: str) -> None:
+    """Ensure the branch name is not already in use."""
+    result = subprocess.run(("git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch_name}"))
+    if result.returncode == 0:
+        raise SystemExit(f"Branch already exists: {branch_name}")
+
+
+def merge_target_branch(branch_name: str, target_reference: str) -> None:
+    """Merge the target branch into the promotion branch."""
+    result = run_command(("git", "merge", target_reference), check=False)
+    if result.returncode == 0:
+        return
+    raise SystemExit(
+        "Merge conflict while preparing the promotion branch. "
+        f"Resolve conflicts on '{branch_name}', commit the merge, and retry PR creation."
+    )
+
+
 def run_validation() -> None:
     """Run the canonical local validation."""
     result = run_command((sys.executable, "scripts/dev/validate_local.py"), check=False)
@@ -179,16 +217,20 @@ def run_validation() -> None:
         raise SystemExit(result.returncode)
 
 
-def create_pull_request(arguments: argparse.Namespace, release_branch: str, main_branch: str) -> None:
-    """Create the release->main pull request."""
-    command = ["gh", "pr", "create", "--base", main_branch, "--head", release_branch]
+def create_pull_request(
+    arguments: argparse.Namespace,
+    promotion_branch: str,
+    main_branch: str,
+    version_label: str,
+) -> None:
+    """Create the promotion->main pull request."""
+    command = ["gh", "pr", "create", "--base", main_branch, "--head", promotion_branch]
     if arguments.draft:
         command.append("--draft")
 
     if arguments.title:
         command.extend(["--title", arguments.title])
     else:
-        version_label = load_version_label()
         command.extend(["--title", f"Promote release {version_label}"])
 
     if arguments.body_file:
@@ -218,8 +260,17 @@ def main(argument_list: Sequence[str] | None = None) -> int:
     ensure_branch_matches_remote(arguments.remote, arguments.release_branch)
     ensure_no_open_pull_requests(arguments.main_branch)
 
+    version_label = load_version_label()
+    promotion_branch_name = arguments.promotion_branch_name or create_promotion_branch_name(version_label)
+    ensure_branch_available(promotion_branch_name)
+
+    run_command(("git", "checkout", "-b", promotion_branch_name))
+    if not arguments.no_target_merge:
+        merge_target_branch(promotion_branch_name, f"{arguments.remote}/{arguments.main_branch}")
     run_validation()
-    create_pull_request(arguments, arguments.release_branch, arguments.main_branch)
+    run_command(("git", "push", "--set-upstream", arguments.remote, promotion_branch_name))
+    create_pull_request(arguments, promotion_branch_name, arguments.main_branch, version_label)
+    run_command(("git", "checkout", arguments.release_branch))
     return 0
 
 

--- a/scripts/dev/submit_release_prs.py
+++ b/scripts/dev/submit_release_prs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Create release and patch-bump pull requests from develop.
+Create release promotion and patch-bump pull requests from develop.
 """
 
 from __future__ import annotations
@@ -47,7 +47,7 @@ def parse_arguments(argument_list: Sequence[str] | None = None) -> argparse.Name
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
         description=(
-            "Create a develop->release PR and a patch-bump PR to develop. "
+            "Create a develop->release PR via a promotion branch and a patch-bump PR to develop. "
             "The patch bump increments PATCH and resets BUILD to 0."
         )
     )
@@ -70,6 +70,11 @@ def parse_arguments(argument_list: Sequence[str] | None = None) -> argparse.Name
         "--patch-branch-name",
         default=None,
         help="Explicit branch name for the patch bump PR.",
+    )
+    parser.add_argument(
+        "--promotion-branch-name",
+        default=None,
+        help="Explicit branch name for the release promotion PR.",
     )
     parser.add_argument(
         "--release-title",
@@ -107,6 +112,11 @@ def parse_arguments(argument_list: Sequence[str] | None = None) -> argparse.Name
         "--draft",
         action="store_true",
         help="Create both pull requests as drafts.",
+    )
+    parser.add_argument(
+        "--no-target-merge",
+        action="store_true",
+        help="Skip merging the release branch into the promotion branch.",
     )
     parser.add_argument(
         "--no-fetch",
@@ -279,11 +289,28 @@ def create_patch_branch_name(version: Version) -> str:
     return f"feature/patch-bump-{version.as_branch_label()}-{timestamp}"
 
 
+def create_promotion_branch_name(version: Version) -> str:
+    """Generate a unique release promotion branch name."""
+    timestamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    return f"promotion/release-{version.as_branch_label()}-{timestamp}"
+
+
 def ensure_branch_available(branch_name: str) -> None:
     """Ensure the branch name is not already in use."""
     result = subprocess.run(("git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch_name}"))
     if result.returncode == 0:
         raise SystemExit(f"Branch already exists: {branch_name}")
+
+
+def merge_target_branch(branch_name: str, target_reference: str) -> None:
+    """Merge the target branch into the promotion branch."""
+    result = run_command(("git", "merge", target_reference), check=False)
+    if result.returncode == 0:
+        return
+    raise SystemExit(
+        "Merge conflict while preparing the promotion branch. "
+        f"Resolve conflicts on '{branch_name}', commit the merge, and retry PR creation."
+    )
 
 
 def run_validation() -> None:
@@ -294,12 +321,12 @@ def run_validation() -> None:
 
 
 def create_release_pull_request(
-    develop_branch: str,
+    promotion_branch: str,
     release_branch: str,
     release_version: Version,
     arguments: argparse.Namespace,
 ) -> None:
-    """Create the develop->release pull request."""
+    """Create the promotion->release pull request."""
     command = [
         "gh",
         "pr",
@@ -307,7 +334,7 @@ def create_release_pull_request(
         "--base",
         release_branch,
         "--head",
-        develop_branch,
+        promotion_branch,
     ]
     if arguments.draft:
         command.append("--draft")
@@ -373,20 +400,28 @@ def main(argument_list: Sequence[str] | None = None) -> int:
     patch_version = bump_patch_version(develop_version)
 
     patch_branch_name = arguments.patch_branch_name or create_patch_branch_name(patch_version)
+    promotion_branch_name = arguments.promotion_branch_name or create_promotion_branch_name(develop_version)
     ensure_branch_available(patch_branch_name)
+    ensure_branch_available(promotion_branch_name)
 
-    run_command(("git", "checkout", "-b", patch_branch_name))
-    update_pyproject_version(develop_version, patch_version)
-    commit_patch_bump(patch_version)
+    run_command(("git", "checkout", "-b", promotion_branch_name))
+    if not arguments.no_target_merge:
+        merge_target_branch(promotion_branch_name, f"{arguments.remote}/{arguments.release_branch}")
     run_validation()
-
-    run_command(("git", "push", "--set-upstream", arguments.remote, patch_branch_name))
+    run_command(("git", "push", "--set-upstream", arguments.remote, promotion_branch_name))
     create_release_pull_request(
-        arguments.develop_branch,
+        promotion_branch_name,
         arguments.release_branch,
         develop_version,
         arguments,
     )
+
+    run_command(("git", "checkout", arguments.develop_branch))
+    run_command(("git", "checkout", "-b", patch_branch_name))
+    update_pyproject_version(develop_version, patch_version)
+    commit_patch_bump(patch_version)
+    run_validation()
+    run_command(("git", "push", "--set-upstream", arguments.remote, patch_branch_name))
     create_patch_pull_request(
         patch_branch_name,
         arguments.develop_branch,


### PR DESCRIPTION
## Summary
- allow promotion/ prefix for promotion branches and document naming
- update promotion scripts to use new naming

## Testing
- python3 scripts/dev/validate_local.py
