### PR TITLE
chore: drop temporary_label column

### DIFF
--- a/alembic/versions/2026-01-13-08-29-abe7b3773eff-drop_temporary_label.py
+++ b/alembic/versions/2026-01-13-08-29-abe7b3773eff-drop_temporary_label.py
@@ -1,0 +1,23 @@
+"""drop_temporary_label
+
+Revision ID: abe7b3773eff
+Revises: f71a73e20503
+Create Date: 2026-01-13 08:29:33.538576
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "abe7b3773eff"
+down_revision = "f71a73e20503"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column("practice", "temporary_label")
+
+
+def downgrade():
+    op.add_column("practice", sa.Column("temporary_label", sa.String(length=120), nullable=True))

--- a/docs/operations/2026-01-13-13-33-end-to-end-validation.md
+++ b/docs/operations/2026-01-13-13-33-end-to-end-validation.md
@@ -1,0 +1,33 @@
+## Actions Taken
+- Note: CLI command timestamps were not captured in the chat; filename timestamp is UTC 2026-01-13 13:33.
+- Created feature branch for the validation run.
+  Command: `git checkout -b feature/remove-temporary-foo`
+  Output: `Switched to a new branch 'feature/remove-temporary-foo'`
+- Removed `practice.temporary_label` from the ORM model and created a migration.
+  Commands:
+  - `poetry run python scripts/dev/alembic_revision.py drop_temporary_label --no-autogenerate`
+  - Migration file: `alembic/versions/2026-01-13-08-29-abe7b3773eff-drop_temporary_label.py`
+  Output: `Generating ... drop_temporary_label.py ... done`
+- Ran Alembic migration validation using a temporary PostgreSQL container.
+  Commands:
+  - `docker run --rm -d --name mnemosys-migrations-postgres -e POSTGRES_USER=mnemosys -e POSTGRES_PASSWORD=mnemosys -e POSTGRES_DB=mnemosys_migrations -p 5433:5432 postgres:16`
+  - `env MNEMOSYS_ENV=development MNEMOSYS_DB_ADMIN_DRIVERNAME=postgresql MNEMOSYS_DB_ADMIN_USERNAME=mnemosys MNEMOSYS_DB_ADMIN_PASSWORD=mnemosys MNEMOSYS_DB_ADMIN_HOST=localhost MNEMOSYS_DB_ADMIN_PORT=5433 MNEMOSYS_DB_ADMIN_DATABASE=mnemosys_migrations poetry run python scripts/dev/validate_migrations.py`
+  - `docker stop mnemosys-migrations-postgres`
+  Output: migration validation succeeded (no output).
+- Ran full local validation.
+  Command: `python3 scripts/dev/validate_local.py`
+  Output: `All checks passed`, `184 passed in 23.74s`, coverage 100%.
+
+## Outcomes and Status
+- `temporary_label` removed from `practice` model and schema.
+- Alembic migration `abe7b3773eff` validates upgrade/downgrade in a temporary schema.
+- Local validation succeeded (ruff, mypy, pytest, coverage, poetry sync --dry-run).
+
+## Problems Encountered and Solved
+- `validate_migrations.py` initially failed with `connection refused` against `localhost:5432`.
+  Resolution: launched a local PostgreSQL 16 container and reran migration validation.
+- `validate_local.py` initially failed due to ruff import ordering and an unused import.
+  Resolution: fixed imports and reran validation successfully.
+
+## Problems Unresolved
+- None.

--- a/src/mnemosys_core/db/models/practice.py
+++ b/src/mnemosys_core/db/models/practice.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from datetime import date  # noqa: TC003
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Date, ForeignKey, Integer, String
+from sqlalchemy import Date, ForeignKey, Integer
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..base import Base
@@ -30,7 +30,6 @@ class Practice(Base):
         session_date: Date of session
         session_type: Intensity level
         total_minutes: Total session duration
-        temporary_label: Optional label for migration workflow checks
     """
 
     __tablename__ = "practice"
@@ -40,7 +39,6 @@ class Practice(Base):
     session_date: Mapped[date] = mapped_column(Date, nullable=False)
     session_type: Mapped[SessionType] = mapped_column(DatabaseEnum(SessionType), nullable=False)
     total_minutes: Mapped[int] = mapped_column(Integer, nullable=False)
-    temporary_label: Mapped[str | None] = mapped_column(String(120), nullable=True)
 
     # Relationships
     instrument: Mapped[Instrument] = relationship("Instrument", back_populates="practices")


### PR DESCRIPTION
## Summary
- remove practice.temporary_label and add migration to drop column
- add ops record for end-to-end validation run

## Testing
- python3 scripts/dev/validate_local.py
- env MNEMOSYS_ENV=development MNEMOSYS_DB_ADMIN_DRIVERNAME=postgresql MNEMOSYS_DB_ADMIN_USERNAME=mnemosys MNEMOSYS_DB_ADMIN_PASSWORD=mnemosys MNEMOSYS_DB_ADMIN_HOST=localhost MNEMOSYS_DB_ADMIN_PORT=5433 MNEMOSYS_DB_ADMIN_DATABASE=mnemosys_migrations poetry run python scripts/dev/validate_migrations.py
