### PR TITLE
Update dependency spec policy and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,5 @@ you plan to run the full local checks.
 
 - Canonical standards and conventions: https://github.com/wphillipmoore/standards-and-conventions
 - Branching and deployment model: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/branching-and-deployment.md
-- Local terminology and overrides: `docs/standards-and-conventions.md`
+- In-repo standards in development and MNEMOSYS terminology: `docs/standards-and-conventions.md`
 - Repository structure ADR: `docs/decisions/0001-repo-structure.md`

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -4,7 +4,13 @@ This repository follows the canonical standards in the Standards and
 Conventions repository:
 https://github.com/wphillipmoore/standards-and-conventions
 
-This file records MNEMOSYS-specific terminology and any local deviations.
+This file records MNEMOSYS-specific terminology and any canonical standards
+incubated here before extraction to the Standards and Conventions repository.
+The Standards and Conventions repository remains the canonical source of truth,
+but MNEMOSYS Core is used to develop new standards that are finalized and
+merged upstream once stable. Differences between this repository and the
+Standards and Conventions repository should be treated as in-progress standards
+unless explicitly documented here as conventions.
 
 ## Table of Contents
 - [Canonical standards](#canonical-standards)
@@ -13,7 +19,7 @@ This file records MNEMOSYS-specific terminology and any local deviations.
   - [Deprecated names](#deprecated-names)
   - [Name rationale](#name-rationale)
   - [Usage in historical documents](#usage-in-historical-documents)
-- [Local deviations](#local-deviations)
+- [In-repo canonical standards](#in-repo-canonical-standards)
 
 ## Canonical standards
 
@@ -79,7 +85,14 @@ Early design documents (v0.1 snapshots) may reference deprecated names in their
 original context. When updating these documents, add a nomenclature note
 explaining the name evolution while preserving the historical snapshot.
 
-## Local deviations
+## In-repo canonical standards
 
-None. Add project-specific overrides here if this repository diverges from the
-canonical standards.
+### Dependency management
+
+Dependency management standards are canonical here and will be extracted to the
+Standards and Conventions repository once stable:
+
+- Default dependency specs in `pyproject.toml` use `"*"`.
+- Do not anchor to a major or minor series by default (including pre-1.0 dependencies).
+- Use constrained specs only when necessary, following the anchored dependency documentation rules.
+- Reevaluate constrained dependencies during each upgrade cycle, per the canonical workflow.

--- a/poetry.lock
+++ b/poetry.lock
@@ -3180,4 +3180,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.14,<4.0"
-content-hash = "bdc3b6a9db6af67a6e061dbb045552cab26773bf4e23a079c07c6df05a93a2f7"
+content-hash = "9138d79e3e8e07871bb0d0c9b215c4064ae7ddf0a96795d1c38227ba94f065b0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,25 +13,25 @@ packages = [{ include = "mnemosys_core", from = "src" }]
 
 [tool.poetry.dependencies]
 python = ">=3.14,<4.0"
-sqlalchemy = ">=2,<3"
-fastapi = ">=0.115,<0.116"
-uvicorn = {extras = ["standard"], version = ">=0.34,<0.35"}
-pydantic = ">=2,<3"
-psycopg2-binary = ">=2,<3"
-alembic = ">=1,<2"
+sqlalchemy = "*"
+fastapi = "*"
+uvicorn = {extras = ["standard"], version = "*"}
+pydantic = "*"
+psycopg2-binary = "*"
+alembic = "*"
 
 [tool.poetry.group.dev.dependencies]
-ruff = ">=0.14,<0.15"
-mypy = ">=1,<2"
-pytest = ">=9,<10"
-pytest-mock = ">=3,<4"
-pytest-cov = ">=7,<8"
-pytest-xdist = ">=3,<4"
-poetry = ">=2,<3"
-poetry-plugin-export = ">=1,<2"
-pre-commit = ">=3,<4"
-httpx = ">=0.27,<0.28"
-testcontainers = ">=4,<5"
+ruff = "*"
+mypy = "*"
+pytest = "*"
+pytest-mock = "*"
+pytest-cov = "*"
+pytest-xdist = "*"
+poetry = "*"
+poetry-plugin-export = "*"
+pre-commit = "*"
+httpx = "*"
+testcontainers = "*"
 
 [tool.ruff]
 line-length = 120

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ cfgv==3.5.0 ; python_version >= "3.14" and python_version < "4.0"
 charset-normalizer==3.4.4 ; python_version >= "3.14" and python_version < "4.0"
 cleo==2.1.0 ; python_version >= "3.14" and python_version < "4.0"
 click==8.3.1 ; python_version >= "3.14" and python_version < "4.0"
-colorama==0.4.6 ; python_version >= "3.14" and python_version < "4.0" and (platform_system == "Windows" or sys_platform == "win32" or os_name == "nt")
+colorama==0.4.6 ; python_version >= "3.14" and python_version < "4.0" and (sys_platform == "win32" or os_name == "nt" or platform_system == "Windows")
 coverage==7.13.1 ; python_version >= "3.14" and python_version < "4.0"
 crashtest==0.4.1 ; python_version >= "3.14" and python_version < "4.0"
 cryptography==46.0.3 ; python_version >= "3.14" and python_version < "4.0" and sys_platform == "linux"

--- a/scripts/dev/validate_dependency_specs.py
+++ b/scripts/dev/validate_dependency_specs.py
@@ -28,65 +28,6 @@ def load_pyproject() -> dict[str, object]:
     with PYPROJECT_PATH.open("rb") as handle:
         return tomllib.load(handle)
 
-
-def parse_version(version_text: str) -> tuple[int, int | None, int | None] | None:
-    if not re.fullmatch(r"\d+(?:\.\d+){0,2}", version_text):
-        return None
-    parts = [int(part) for part in version_text.split(".")]
-    major = parts[0]
-    minor = parts[1] if len(parts) > 1 else None
-    patch = parts[2] if len(parts) > 2 else None
-    return major, minor, patch
-
-
-def parse_range_spec(spec_text: str) -> tuple[tuple[int, int | None, int | None], tuple[int, int | None, int | None]] | None:
-    parts = [part.strip() for part in spec_text.split(",") if part.strip()]
-    if len(parts) != 2:
-        return None
-
-    lower_part = next((part for part in parts if part.startswith(">=")), None)
-    upper_part = next((part for part in parts if part.startswith("<")), None)
-    if lower_part is None or upper_part is None:
-        return None
-
-    if lower_part.startswith(">") and not lower_part.startswith(">="):
-        return None
-    if upper_part.startswith("<="):
-        return None
-
-    lower_version = parse_version(lower_part[2:].strip())
-    upper_version = parse_version(upper_part[1:].strip())
-    if lower_version is None or upper_version is None:
-        return None
-
-    return lower_version, upper_version
-
-
-def is_standard_range(spec_text: str) -> bool:
-    parsed = parse_range_spec(spec_text)
-    if parsed is None:
-        return False
-    lower_version, upper_version = parsed
-    lower_major, lower_minor, lower_patch = lower_version
-    upper_major, upper_minor, upper_patch = upper_version
-
-    if lower_major == 0:
-        if upper_major != 0 or lower_minor is None or upper_minor is None:
-            return False
-        if upper_minor != lower_minor + 1:
-            return False
-        return lower_patch in (None, 0) and upper_patch in (None, 0)
-
-    if upper_major != lower_major + 1:
-        return False
-    return (
-        lower_minor in (None, 0)
-        and lower_patch in (None, 0)
-        and upper_minor in (None, 0)
-        and upper_patch in (None, 0)
-    )
-
-
 def collect_dependency_lines(lines: list[str]) -> dict[tuple[str, str], int]:
     current_section: str | None = None
     dependency_lines: dict[tuple[str, str], int] = {}
@@ -173,11 +114,7 @@ def validate_dependency_specs() -> None:
                 errors.append(f"{section_name}:{dependency_name} has no version specifier.")
                 continue
 
-            if "*" in spec_text:
-                errors.append(f"{section_name}:{dependency_name} uses '*' which is forbidden.")
-                continue
-
-            if is_standard_range(spec_text):
+            if spec_text == "*":
                 continue
 
             line_index = dependency_lines.get((section_name, dependency_name))
@@ -190,7 +127,8 @@ def validate_dependency_specs() -> None:
 
             if anchor_comment is None:
                 errors.append(
-                    f"{section_name}:{dependency_name} requires anchor comment '{ANCHOR_PREFIX}' with record reference."
+                    f"{section_name}:{dependency_name} uses a non-default spec and requires anchor comment "
+                    f"'{ANCHOR_PREFIX}' with record reference."
                 )
             elif f"docs/dependencies/{dependency_name}.md" not in anchor_comment:
                 errors.append(


### PR DESCRIPTION
## Summary
- default dependency specs to "*" and require anchors only for constrained specs
- document in-repo canonical standards development and align README wording
- refresh lockfile and exported requirements

## Testing
- `python3 scripts/dev/validate_local.py`
