### PR TITLE
Enable Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
# Pull Request

## Summary
- Enable Dependabot update checks for pip and GitHub Actions

## Issue Linkage
- Fixes #133
- Work is not complete until the issue is closed.

## Testing
- `python scripts/dev/validate_local.py`

## Notes
- None.
