### PR TITLE
docs: require canonical standards access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,8 +104,12 @@ rm /tmp/pr-body.txt
 
 ### Required Reading Before Common Operations
 
+If any required canonical standard cannot be retrieved, treat it as a fatal
+exception: stop and notify the user. Do not proceed with assumptions or
+alternate sources.
+
 **Git Operations (commit, push, branch, merge)**
-- **MUST READ**: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/branching-and-deployment.md
+- **MUST READ**: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/branching-and-deployment.md
 - **Key Rules**:
   - NEVER push directly to develop/main/release (eternal branches)
   - ALL changes to eternal branches MUST go through pull requests
@@ -113,8 +117,8 @@ rm /tmp/pr-body.txt
   - NEVER reuse old branch names
 
 **Pull Request Operations (creating, submitting, merging)**
-- **MUST READ**: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/pull-request-workflow.md#pre-submission-requirements
-- **MUST READ**: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/pull-request-workflow.md#pull-request-finalization
+- **MUST READ**: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/pull-request-workflow.md#pre-submission-requirements
+- **MUST READ**: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/pull-request-workflow.md#pull-request-finalization
 - **Key Rules**:
   - 100% test success required before PR creation
   - 100% line AND branch coverage required
@@ -122,7 +126,7 @@ rm /tmp/pr-body.txt
   - Follow three-step finalization process after merge
 
 **Code Quality and Standards**
-- **MUST READ**: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/development/python/overview.md
+- **MUST READ**: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/development/python/overview.md
 - **Key Rules**:
   - PEP-compliant code only
   - Complete type hints for all public functions
@@ -130,7 +134,7 @@ rm /tmp/pr-body.txt
   - No abbreviations in variable names (minimum 3 characters)
 
 **Database Changes (models, migrations, schema)**
-- **MUST READ**: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/development/database/conventions.md
+- **MUST READ**: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/development/database/conventions.md
 - **Key Rules**:
   - Table names are singular, not plural
   - Follow model file organization rules
@@ -154,7 +158,7 @@ The 30 seconds spent reading documentation prevents hours of cleanup work.
 **Docs-Only Exception**: If the diff includes **only** documentation files (anything under `docs/` plus top-level
 `README.md` or `CHANGELOG.md`), skip both confirmation checkpoints and proceed directly through PR creation
 and finalization. Local validation is optional per the docs-only rule in
-https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/pull-request-workflow.md.
+https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/pull-request-workflow.md.
 If any non-documentation file changes, the checkpoints remain mandatory.
 
 **Finalize Override**: If the user explicitly says **"Finalize PR"**, treat that as approval to submit and

--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ you plan to run the full local checks.
 
 ## Where the Rules Live
 
-- Canonical standards and conventions: https://github.com/wphillipmoore/standards-and-conventions
-- Branching and deployment model: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/branching-and-deployment.md
+- Canonical standards and conventions: https://github.com/wphillipmoore/standards-and-conventions/tree/develop
+- Branching and deployment model: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/branching-and-deployment.md
 - In-repo standards in development and MNEMOSYS terminology: `docs/standards-and-conventions.md`
 - Repository structure ADR: `docs/decisions/0001-repo-structure.md`
+
+If the canonical standards cannot be retrieved, treat it as a fatal exception
+and notify the user before proceeding.

--- a/docs/project/draft/Architecture_Standards_and_Conventions.md
+++ b/docs/project/draft/Architecture_Standards_and_Conventions.md
@@ -1,7 +1,7 @@
 # Architecture Standards and Conventions
 
 This document is maintained in the Standards and Conventions repository:
-https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/foundation/architecture-standards.md
+https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/foundation/architecture-standards.md
 
 ## Table of Contents
 - [Source of truth](#source-of-truth)
@@ -10,7 +10,9 @@ https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/founda
 ## Source of truth
 
 The canonical version lives at:
-https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/foundation/architecture-standards.md
+https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/foundation/architecture-standards.md
+If the canonical document cannot be retrieved, treat it as a fatal exception
+and notify the user.
 
 ## Local deviations
 

--- a/docs/project/final/AI_Assisted_Development_Approach.md
+++ b/docs/project/final/AI_Assisted_Development_Approach.md
@@ -1,7 +1,7 @@
 # AI-Assisted Development Loop
 
 This document is maintained in the Standards and Conventions repository:
-https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/foundation/ai-assisted-development-loop.md
+https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/foundation/ai-assisted-development-loop.md
 
 ## Table of Contents
 - [Source of truth](#source-of-truth)
@@ -10,7 +10,9 @@ https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/founda
 ## Source of truth
 
 The canonical version lives at:
-https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/foundation/ai-assisted-development-loop.md
+https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/foundation/ai-assisted-development-loop.md
+If the canonical document cannot be retrieved, treat it as a fatal exception
+and notify the user.
 
 ## Local deviations
 

--- a/docs/project/final/AI_Code_Review_Guidelines.md
+++ b/docs/project/final/AI_Code_Review_Guidelines.md
@@ -1,7 +1,7 @@
 # AI Code Review Guidelines
 
 This document is maintained in the Standards and Conventions repository:
-https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/foundation/ai-code-review-guidelines.md
+https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/foundation/ai-code-review-guidelines.md
 
 ## Table of Contents
 - [Source of truth](#source-of-truth)
@@ -10,7 +10,9 @@ https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/founda
 ## Source of truth
 
 The canonical version lives at:
-https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/foundation/ai-code-review-guidelines.md
+https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/foundation/ai-code-review-guidelines.md
+If the canonical document cannot be retrieved, treat it as a fatal exception
+and notify the user.
 
 ## Local deviations
 

--- a/docs/project/final/Development_Branching_Deployment_Model.md
+++ b/docs/project/final/Development_Branching_Deployment_Model.md
@@ -1,7 +1,7 @@
 # Development Branching and Deployment Model
 
 This document is maintained in the Standards and Conventions repository:
-https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/branching-and-deployment.md
+https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/branching-and-deployment.md
 
 ## Table of Contents
 - [Source of truth](#source-of-truth)
@@ -10,7 +10,9 @@ https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-m
 ## Source of truth
 
 The canonical version lives at:
-https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/branching-and-deployment.md
+https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/branching-and-deployment.md
+If the canonical document cannot be retrieved, treat it as a fatal exception
+and notify the user.
 
 ## Local deviations
 

--- a/docs/project/final/Development_Hotfix_Policy.md
+++ b/docs/project/final/Development_Hotfix_Policy.md
@@ -1,7 +1,7 @@
 # Development Hotfix Policy
 
 This document is maintained in the Standards and Conventions repository:
-https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/hotfix-policy.md
+https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/hotfix-policy.md
 
 ## Table of Contents
 - [Source of truth](#source-of-truth)
@@ -10,7 +10,9 @@ https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-m
 ## Source of truth
 
 The canonical version lives at:
-https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/hotfix-policy.md
+https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/hotfix-policy.md
+If the canonical document cannot be retrieved, treat it as a fatal exception
+and notify the user.
 
 ## Local deviations
 

--- a/docs/project/final/Development_Release_Versioning_Policy.md
+++ b/docs/project/final/Development_Release_Versioning_Policy.md
@@ -1,7 +1,7 @@
 # Development Release Versioning Policy
 
 This document is maintained in the Standards and Conventions repository:
-https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/release-versioning.md
+https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/release-versioning.md
 
 ## Table of Contents
 - [Source of truth](#source-of-truth)
@@ -10,7 +10,9 @@ https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-m
 ## Source of truth
 
 The canonical version lives at:
-https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/release-versioning.md
+https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/release-versioning.md
+If the canonical document cannot be retrieved, treat it as a fatal exception
+and notify the user.
 
 ## Local deviations
 

--- a/docs/project/final/Source_Code_Management_Guidelines.md
+++ b/docs/project/final/Source_Code_Management_Guidelines.md
@@ -1,7 +1,7 @@
 # Source Code Management Guidelines
 
 This document is maintained in the Standards and Conventions repository:
-https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/source-control-guidelines.md
+https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/source-control-guidelines.md
 
 ## Table of Contents
 - [Source of truth](#source-of-truth)
@@ -10,7 +10,9 @@ https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-m
 ## Source of truth
 
 The canonical version lives at:
-https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/source-control-guidelines.md
+https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/source-control-guidelines.md
+If the canonical document cannot be retrieved, treat it as a fatal exception
+and notify the user.
 
 ## Local deviations
 

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -2,7 +2,7 @@
 
 This repository follows the canonical standards in the Standards and
 Conventions repository:
-https://github.com/wphillipmoore/standards-and-conventions
+https://github.com/wphillipmoore/standards-and-conventions/tree/develop
 
 This file records MNEMOSYS-specific terminology and any canonical standards
 incubated here before extraction to the Standards and Conventions repository.
@@ -14,6 +14,7 @@ unless explicitly documented here as conventions.
 
 ## Table of Contents
 - [Canonical standards](#canonical-standards)
+  - [Access requirements](#access-requirements)
 - [Project terminology](#project-terminology)
   - [Official project name](#official-project-name)
   - [Deprecated names](#deprecated-names)
@@ -27,25 +28,35 @@ unless explicitly documented here as conventions.
 
 Start with these sources of truth:
 
-- Code management overview: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/overview.md
-- Pull request workflow: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/pull-request-workflow.md
-- Commit messages and authorship: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/commit-messages-and-authorship.md
-- Branching and deployment: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/branching-and-deployment.md
-- Release versioning: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/release-versioning.md
-- Hotfix policy: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/hotfix-policy.md
-- Development overview: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/development/overview.md
-- Environment and tooling: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/development/environment-and-tooling.md
-- Python standards overview: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/development/python/overview.md
-- Python naming conventions: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/development/python/naming-conventions.md
-- Python import-time side effects: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/development/python/import-time-side-effects.md
-- Python type hints: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/development/python/type-hints.md
-- Python testing and coverage: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/development/python/testing-and-coverage.md
-- Database conventions: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/development/database/conventions.md
-- Repository standards overview: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/repository/overview.md
-- Markdown standards: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/foundation/markdown-standards.md
-- Architecture standards: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/foundation/architecture-standards.md
-- AI code review guidelines: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/foundation/ai-code-review-guidelines.md
-- AI-assisted development loop: https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/foundation/ai-assisted-development-loop.md
+### Access requirements
+
+When reading canonical standards, use the raw GitHub content endpoint for
+deterministic access:
+`https://raw.githubusercontent.com/wphillipmoore/standards-and-conventions/develop/<path>`
+
+If the canonical docs cannot be retrieved (network failure, access failure, or
+missing file), treat it as a fatal exception: stop and notify the user. Do not
+proceed with assumptions or alternate sources.
+
+- Code management overview: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/overview.md
+- Pull request workflow: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/pull-request-workflow.md
+- Commit messages and authorship: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/commit-messages-and-authorship.md
+- Branching and deployment: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/branching-and-deployment.md
+- Release versioning: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/release-versioning.md
+- Hotfix policy: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/hotfix-policy.md
+- Development overview: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/development/overview.md
+- Environment and tooling: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/development/environment-and-tooling.md
+- Python standards overview: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/development/python/overview.md
+- Python naming conventions: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/development/python/naming-conventions.md
+- Python import-time side effects: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/development/python/import-time-side-effects.md
+- Python type hints: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/development/python/type-hints.md
+- Python testing and coverage: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/development/python/testing-and-coverage.md
+- Database conventions: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/development/database/conventions.md
+- Repository standards overview: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/repository/overview.md
+- Markdown standards: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/foundation/markdown-standards.md
+- Architecture standards: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/foundation/architecture-standards.md
+- AI code review guidelines: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/foundation/ai-code-review-guidelines.md
+- AI-assisted development loop: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/foundation/ai-assisted-development-loop.md
 
 ## Project terminology
 


### PR DESCRIPTION
# Pull Request

## Summary
- Require reliable access to canonical standards and treat failures as fatal.
- Point standards-and-conventions references at the develop branch and raw endpoints.

## Issue Linkage
- No issue. Docs-only workflow alignment.

## Testing
- Docs-only: tests skipped.

## Notes
- Standards references updated across README, AGENTS, and standards wrappers.
