### PR TITLE
docs: add dependency update workflow

### DIFF
--- a/docs/project/final/dependency-update-workflow.md
+++ b/docs/project/final/dependency-update-workflow.md
@@ -1,0 +1,24 @@
+# Dependency Update Workflow
+
+This document is maintained in the Standards and Conventions repository:
+https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/development/dependency-update-workflow.md
+
+## Table of Contents
+- [Source of truth](#source-of-truth)
+- [Local deviations](#local-deviations)
+
+## Source of truth
+
+The canonical version lives at:
+https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/development/dependency-update-workflow.md
+
+If the canonical document cannot be retrieved, treat it as a fatal exception
+and notify the user.
+
+## Local deviations
+
+- Review Dependabot alerts during `MAJOR` and `MINOR` releases and incorporate
+  remediation into the dependency update process.
+- If an attempted upgrade fails, create a GitHub issue describing the failure,
+  pin the dependency to the last known good version, and add a pin comment that
+  references the issue.

--- a/docs/project/final/version-string-management.md
+++ b/docs/project/final/version-string-management.md
@@ -92,7 +92,9 @@ The PR author (human or AI) owns the bump; CI must reject missing increments.
 2. If `release` has diverged, merge `release` into the promotion branch and
    resolve conflicts in the promotion branch before PR merge.
 3. For `MAJOR` or `MINOR` releases, review Dependabot alerts and address them
-   as part of the dependency update process before the release PR is merged.
+   as part of the dependency update process (see
+   `docs/project/final/dependency-update-workflow.md`) before the release PR is
+   merged.
 4. Immediately open a separate PR to `develop` that increments `PATCH` by 1 and
    resets `BUILD` to `0`.
 5. Merge the promotion PR after validation using a merge commit (no squash).

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -23,6 +23,7 @@ unless explicitly documented here as conventions.
 - [Project-specific overrides](#project-specific-overrides)
   - [AI co-author identities](#ai-co-author-identities)
 - [In-repo canonical standards](#in-repo-canonical-standards)
+  - [Dependency update workflow](#dependency-update-workflow)
 
 ## Canonical standards
 
@@ -132,3 +133,7 @@ Co-Authored-By: mnemosys-claude <252602472+mnemosys-claude@users.noreply.github.
 - JSON/JSONB is acceptable only when the data shape is unstable or evolving fast enough
   that normalization would churn.
 - Treat JSON storage as provisional; revisit and normalize once the schema stabilizes.
+
+### Dependency update workflow
+
+See `docs/project/final/dependency-update-workflow.md`.


### PR DESCRIPTION
# Pull Request

## Summary
- Add a dependency update workflow wrapper that defers to canonical standards.
- Document local deviations for Dependabot alert review and failed upgrade handling.

## Issue Linkage
- No issue. Documentation alignment.

## Testing
- Docs-only: tests skipped.

## Notes
- Canonical workflow reference lives in standards-and-conventions.
