### PR TITLE
docs: require python3 usage and venv activation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,11 +56,13 @@ No implicit state or side effects at import time. The database engine, models, a
 ## Useful Commands
 
 ```bash
+# All commands assume the .venv is active. Always use python3 for Python invocations.
+
 # Run tests
 pytest tests/
 
 # Database bootstrap (local development only)
-python scripts/dev/bootstrap_db.py
+python3 scripts/dev/bootstrap_db.py
 
 # Type checking (setup if mypy is configured)
 # Check .github/workflows/ci.yml for current CI commands

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@
 - If no issue exists, state why and open one before merge.
 
 ## Testing
-- `python scripts/dev/validate_local.py`
+- `python3 scripts/dev/validate_local.py`
 
 ## Notes
 - 

--- a/.github/workflows/deploy-nonprod.yml
+++ b/.github/workflows/deploy-nonprod.yml
@@ -61,7 +61,7 @@ jobs:
         env:
           AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
         run: |
-          python scripts/deploy/render_task_definition.py \
+          python3 scripts/deploy/render_task_definition.py \
             --template "${TASK_DEFINITION_TEMPLATE}" \
             --output "task-def.rendered.json" \
             --environment "${ENVIRONMENT}" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,7 +186,7 @@ Before pushing the branch or submitting a PR, you MUST run and pass the full loc
 
 ```bash
 # Run local validation (mirrors CI hard gates)
-python scripts/dev/validate_local.py
+python3 scripts/dev/validate_local.py
 ```
 
 **All checks must pass with:**
@@ -309,11 +309,11 @@ git clone <repository-url>
 cd mnemosys-core
 
 # Create and activate virtual environment (recommended)
-python -m venv .venv
+python3 -m venv .venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 
 # Install dependencies
-pip install -e .
+python3 -m pip install -e .
 ```
 
 ### Database Bootstrapping
@@ -321,7 +321,7 @@ pip install -e .
 For local development:
 
 ```bash
-python scripts/dev/bootstrap_db.py
+python3 scripts/dev/bootstrap_db.py
 ```
 
 ### Running Tests

--- a/README.md
+++ b/README.md
@@ -22,18 +22,21 @@ are created explicitly.
 Requires Python 3.14+.
 
 ```bash
-python -m venv .venv
+python3 -m venv .venv
 source .venv/bin/activate
-pip install -e .
+python3 -m pip install -e .
 ```
 
-Use the virtual environment for all Python invocations. On macOS, `python`
-may not exist outside the venv.
+Use the virtual environment for all Python invocations and always call
+`python3` (never `python`). On macOS, `python` may not exist outside the venv.
 
 ## Development
 
 Before starting any new development effort, run the unit tests and confirm they
 pass. This avoids inheriting broken local artifacts from prior work.
+
+All commands below assume the `.venv` is active. Always use `python3` for
+Python invocations.
 
 ```bash
 pytest tests/
@@ -41,13 +44,13 @@ pytest tests/
 
 ```bash
 # Full local validation (tests, coverage, lint, type check)
-python scripts/dev/validate_local.py
+python3 scripts/dev/validate_local.py
 
 # Run tests only
 pytest tests/
 
 # Bootstrap a local database (if needed)
-python scripts/dev/bootstrap_db.py
+python3 scripts/dev/bootstrap_db.py
 ```
 
 Note: the validation script uses Poetry under the hood; install Poetry if

--- a/alembic/README.md
+++ b/alembic/README.md
@@ -10,12 +10,15 @@ This directory contains Alembic database migration scripts for the mnemosys-core
 - [Migration History](#migration-history)
 - [Environment Configuration](#environment-configuration)
 
+All commands below assume the `.venv` is active and use `python3` for Python
+invocations.
+
 ## Generating Migrations
 
 Create a new migration after modifying models (message must be short `snake_case`, <= 60 chars):
 
 ```bash
-python scripts/dev/alembic_revision.py add_column_to_practice
+python3 scripts/dev/alembic_revision.py add_column_to_practice
 ```
 
 ## Applying Migrations
@@ -45,13 +48,13 @@ alembic downgrade <revision_id>
 Validate upgrade/downgrade in a temporary schema (PostgreSQL only):
 
 ```bash
-python scripts/dev/validate_migrations.py
+python3 scripts/dev/validate_migrations.py
 ```
 
 Optional seed script:
 
 ```bash
-python scripts/dev/validate_migrations.py --seed-script <path-to-seed-script>
+python3 scripts/dev/validate_migrations.py --seed-script <path-to-seed-script>
 ```
 
 ## Migration History

--- a/docs/plans/in-progress/2026-01-03-alembic-schema-management-design.md
+++ b/docs/plans/in-progress/2026-01-03-alembic-schema-management-design.md
@@ -240,16 +240,16 @@ ALTER DEFAULT PRIVILEGES FOR ROLE mnemosys_sandbox_admin IN SCHEMA mnemosys
 1. Update SQLAlchemy models.
 2. Generate a revision:
    ```bash
-   python scripts/dev/alembic_revision.py short_snake_case_message
+   python3 scripts/dev/alembic_revision.py short_snake_case_message
    ```
 3. Review the revision and edit by hand if needed.
 4. Run automated migration validation (temp schema upgrade/downgrade):
    ```bash
-   python scripts/dev/validate_migrations.py
+   python3 scripts/dev/validate_migrations.py
    ```
    Optional seed script:
    ```bash
-   python scripts/dev/validate_migrations.py --seed-script <path-to-seed-script>
+   python3 scripts/dev/validate_migrations.py --seed-script <path-to-seed-script>
    ```
 5. Commit the revision file and model changes.
 
@@ -378,7 +378,7 @@ Phase 5: Operational integration (pending)
 - Add observability hooks (logs/metrics) for migration steps.
 
 Phase 6: End-to-end validation (pending)
-- Run full local validation (`python scripts/dev/validate_local.py`) with migration checks included.
+- Run full local validation (`python3 scripts/dev/validate_local.py`) with migration checks included.
 - Dry-run the deployment sequence in a non-production environment.
 
 ## Open Questions

--- a/docs/plans/pending/2026-01-06-alembic-release-squash-and-extraction-plan.md
+++ b/docs/plans/pending/2026-01-06-alembic-release-squash-and-extraction-plan.md
@@ -49,9 +49,9 @@ This plan extends `docs/plans/in-progress/2026-01-03-alembic-schema-management-d
 ## End-to-End Pipeline Validation
 
 1. Create a reversible dummy model change and generate a revision via
-   `python scripts/dev/alembic_revision.py <short_snake_case>`.
+   `python3 scripts/dev/alembic_revision.py <short_snake_case>`.
 2. Validate locally in the sandbox only:
-   `python scripts/dev/validate_migrations.py`.
+   `python3 scripts/dev/validate_migrations.py`.
 3. Open PR to `develop` and merge.
    - GitHub Actions deploys to development.
    - Migration gate runs via pipeline (no manual migration).

--- a/docs/project/final/version-string-management.md
+++ b/docs/project/final/version-string-management.md
@@ -20,6 +20,6 @@ and notify the user.
 - The canonical version string for MNEMOSYS Core lives in `pyproject.toml` under
   `project.version`.
 - Use the local helper scripts when available:
-  - `python scripts/dev/submit_develop_pr.py`
-  - `python scripts/dev/submit_release_prs.py`
-  - `python scripts/dev/submit_main_pr.py`
+  - `python3 scripts/dev/submit_develop_pr.py`
+  - `python3 scripts/dev/submit_release_prs.py`
+  - `python3 scripts/dev/submit_main_pr.py`

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -109,11 +109,12 @@ Before starting any new development effort, run the unit tests and confirm they
 pass. This guards against inheriting broken local artifacts from prior work.
 
 All Python commands must run inside the project venv (use `poetry run ...` or
-the `.venv/bin/python` interpreter). Do not rely on a system `python` binary.
+the `.venv/bin/python3` interpreter). Do not rely on a system `python` binary;
+use `python3` for all Python invocations.
 
 Use one of:
 - `pytest tests/`
-- `python scripts/dev/validate_local.py`
+- `python3 scripts/dev/validate_local.py`
 
 ### AI co-author identities
 

--- a/scripts/dev/validate_venv.py
+++ b/scripts/dev/validate_venv.py
@@ -68,7 +68,7 @@ def validate_venv() -> None:
     if not venv_path.is_dir():
         raise SystemExit("Missing .venv. Rebuild with: python3 -m venv .venv")
 
-    python_path = venv_path / "bin" / "python"
+    python_path = venv_path / "bin" / "python3"
     if not python_path.exists():
         raise SystemExit(f"Missing venv interpreter: {python_path}")
 

--- a/scripts/runtime/entrypoint.sh
+++ b/scripts/runtime/entrypoint.sh
@@ -7,7 +7,7 @@ if [[ -z "${MNEMOSYS_ENV:-}" ]]; then
 fi
 
 echo "Running Alembic migration gate..."
-python /app/alembic/runner.py upgrade
+python3 /app/alembic/runner.py upgrade
 
 uvicorn_args=(
   "mnemosys_core.api.runtime:create_application"


### PR DESCRIPTION
# Pull Request

## Summary
- Switch Python invocations to `python3` across docs, templates, and workflows.
- Clarify venv usage expectations in developer docs.
- Align venv validation to require a python3 interpreter.

## Issue Linkage
- None.
- Work is not complete until the issue is closed.
- If no issue exists, state why and open one before merge.

## Testing
- `poetry run python3 scripts/dev/validate_local.py`

## Notes
- Ran `poetry run pytest tests/` before full validation.
