### PR TITLE
Align CI gate docs with standards

### DIFF
--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -101,15 +101,7 @@ explaining the name evolution while preserving the historical snapshot.
 
 ### CI gates
 
-Every CI check is classified as a hard gate or soft gate.
-
-Hard gate definition:
-- Merge-blocking. A required status check must be configured on the target
-  branch. Any failure blocks merge until a new commit passes.
-
-Soft gate definition:
-- Warning-only. The check can fail without blocking merge, but failures must be
-  surfaced with rationale and follow-up tracking when applicable.
+CI gate definitions follow the canonical standards.
 
 Hard gates (all are required status checks):
 - `test-and-validate (3.14)`
@@ -117,7 +109,7 @@ Hard gates (all are required status checks):
 - `dependency-audit`
 
 Soft gates:
-- None (default to hard gate until documented).
+- None.
 
 Branch applicability:
 - develop: all hard gates required

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "mnemosys-core"
-version = "0.1.3.3"
+version = "0.1.3.4"
 description = "Core backend for the MNEMOSYS system"
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
# Pull Request

## Summary
- Align local CI gate documentation with updated standards by removing duplicate definitions.
- Bump version to satisfy the version gate.

## Issue Linkage
- Fixes #171
- Work is not complete until the issue is closed.

## Testing
- `python3 scripts/dev/validate_local.py`

## Notes
- Files changed: `docs/standards-and-conventions.md`, `pyproject.toml`
