### PR TITLE
chore: enforce markdownlint version for docs validation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@
 
 ## Testing
 - `python3 scripts/dev/validate_local.py`
+- Docs-only: `python3 scripts/dev/validate_docs.py`
 
 ## Notes
 - 

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -145,6 +145,8 @@ Use one of:
 - `python3 scripts/dev/validate_local.py`
 - Docs-only changes: `python3 scripts/dev/validate_docs.py`
 
+Docs-only validation requires `markdownlint` to be available on the PATH.
+
 ### AI co-author identities
 
 Approved AI co-author trailers for this repository:

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -143,6 +143,7 @@ use `python3` for all Python invocations.
 Use one of:
 - `pytest tests/`
 - `python3 scripts/dev/validate_local.py`
+- Docs-only changes: `python3 scripts/dev/validate_docs.py`
 
 ### AI co-author identities
 

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -145,7 +145,9 @@ Use one of:
 - `python3 scripts/dev/validate_local.py`
 - Docs-only changes: `python3 scripts/dev/validate_docs.py`
 
-Docs-only validation requires `markdownlint` to be available on the PATH.
+Docs-only validation requires `markdownlint` `0.41.0` on the PATH. If it is not
+available, `npx` must be installed so the validation script can run the pinned
+version.
 
 ### AI co-author identities
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "mnemosys-core"
-version = "0.1.3.6"
+version = "0.1.3.7"
 description = "Core backend for the MNEMOSYS system"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/scripts/dev/validate_docs.py
+++ b/scripts/dev/validate_docs.py
@@ -49,8 +49,10 @@ def run_markdownlint(paths: list[str]) -> int:
     """Run markdownlint if available."""
     markdownlint = shutil.which("markdownlint")
     if not markdownlint:
-        print("warning: markdownlint not found; skipping markdown lint")
-        return 0
+        raise SystemExit(
+            "markdownlint is required for docs-only validation. "
+            "Install markdownlint and retry."
+        )
 
     if not paths:
         print("No markdown files found to validate.")

--- a/scripts/dev/validate_docs.py
+++ b/scripts/dev/validate_docs.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+Docs-only validation helper.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Run docs-only validation.")
+    parser.add_argument(
+        "--paths",
+        nargs="*",
+        default=None,
+        help="Optional list of markdown files to validate.",
+    )
+    return parser.parse_args()
+
+
+def ensure_project_root() -> None:
+    """Fail fast if invoked outside the repository root."""
+    if not Path("pyproject.toml").is_file():
+        raise SystemExit("Run from the repository root (pyproject.toml missing).")
+
+
+def gather_default_paths() -> list[str]:
+    """Collect default markdown files for docs-only validation."""
+    candidates: list[Path] = []
+    docs_root = Path("docs")
+    if docs_root.exists():
+        candidates.extend(docs_root.rglob("*.md"))
+
+    for filename in ("README.md", "CHANGELOG.md"):
+        path = Path(filename)
+        if path.is_file():
+            candidates.append(path)
+
+    unique_paths = sorted(set(candidates))
+    return [str(path) for path in unique_paths]
+
+
+def run_markdownlint(paths: list[str]) -> int:
+    """Run markdownlint if available."""
+    markdownlint = shutil.which("markdownlint")
+    if not markdownlint:
+        print("warning: markdownlint not found; skipping markdown lint")
+        return 0
+
+    if not paths:
+        print("No markdown files found to validate.")
+        return 0
+
+    command = (markdownlint, *paths)
+    print(f"Running: {' '.join(command)}")
+    return subprocess.run(command).returncode
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    ensure_project_root()
+
+    paths = arguments.paths or gather_default_paths()
+    return run_markdownlint(paths)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/validate_docs.py
+++ b/scripts/dev/validate_docs.py
@@ -10,6 +10,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+MARKDOWNLINT_VERSION = "0.41.0"
+
 
 def parse_arguments() -> argparse.Namespace:
     """Parse command line arguments."""
@@ -45,20 +47,42 @@ def gather_default_paths() -> list[str]:
     return [str(path) for path in unique_paths]
 
 
-def run_markdownlint(paths: list[str]) -> int:
-    """Run markdownlint if available."""
+def resolve_markdownlint() -> tuple[str, str]:
+    """Resolve markdownlint binary and version."""
     markdownlint = shutil.which("markdownlint")
-    if not markdownlint:
+    if markdownlint:
+        version_output = subprocess.run(
+            (markdownlint, "--version"), check=True, text=True, capture_output=True
+        ).stdout.strip()
+        if version_output != MARKDOWNLINT_VERSION:
+            raise SystemExit(
+                "markdownlint version mismatch. "
+                f"Expected {MARKDOWNLINT_VERSION}, found {version_output}."
+            )
+        return markdownlint, version_output
+
+    npx = shutil.which("npx")
+    if not npx:
         raise SystemExit(
             "markdownlint is required for docs-only validation. "
-            "Install markdownlint and retry."
+            "Install markdownlint or ensure npx is available."
         )
+
+    return npx, MARKDOWNLINT_VERSION
+
+
+def run_markdownlint(paths: list[str]) -> int:
+    """Run markdownlint using the resolved toolchain."""
+    markdownlint_cmd, version = resolve_markdownlint()
 
     if not paths:
         print("No markdown files found to validate.")
         return 0
 
-    command = (markdownlint, *paths)
+    if markdownlint_cmd.endswith("markdownlint"):
+        command = (markdownlint_cmd, *paths)
+    else:
+        command = (markdownlint_cmd, "--yes", f"markdownlint-cli@{version}", *paths)
     print(f"Running: {' '.join(command)}")
     return subprocess.run(command).returncode
 


### PR DESCRIPTION
# Pull Request

## Summary
- Enforce a pinned markdownlint version for docs-only validation.
- Allow npx fallback to run the pinned markdownlint-cli when not installed.

## Issue Linkage
- Fixes #178

## Testing
- poetry run python3 scripts/dev/validate_local.py

## Notes
- None.
