### PR TITLE
fix: skip version check when validating develop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "mnemosys-core"
-version = "0.1.3.9"
+version = "0.1.3.10"
 description = "Core backend for the MNEMOSYS system"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/scripts/dev/validate_local.py
+++ b/scripts/dev/validate_local.py
@@ -33,6 +33,15 @@ def read_command_output(command: tuple[str, ...]) -> str:
     return result.stdout.strip()
 
 
+def current_branch_name() -> str | None:
+    """Return the current branch name, or None if detached."""
+    try:
+        reference = read_command_output(("git", "symbolic-ref", "--quiet", "HEAD"))
+    except subprocess.CalledProcessError:
+        return None
+    return reference.rsplit("/", maxsplit=1)[-1] if reference else None
+
+
 def resolve_default_base_ref() -> str | None:
     """Resolve the default base ref from origin/HEAD."""
     try:
@@ -42,12 +51,11 @@ def resolve_default_base_ref() -> str | None:
     return reference.rsplit("/", maxsplit=1)[-1] if reference else None
 
 
-def build_commands(base_ref: str) -> tuple[tuple[str, ...], ...]:
+def build_commands(base_ref: str, skip_version_check: bool) -> tuple[tuple[str, ...], ...]:
     """Build validation commands matching CI hard gates."""
-    return (
+    commands: list[tuple[str, ...]] = [
         ("python3", "scripts/dev/validate_venv.py"),
         ("python3", "scripts/dev/validate_dependency_specs.py"),
-        ("python3", "scripts/dev/validate_version.py", "--base-ref", base_ref),
         ("poetry", "check", "--lock"),
         ("poetry", "sync", "--dry-run"),
         ("poetry", "run", "pip-audit", "-r", "requirements.txt", "-r", "requirements-dev.txt"),
@@ -66,7 +74,10 @@ def build_commands(base_ref: str) -> tuple[tuple[str, ...], ...]:
             "--cov-fail-under=100",
         ),
         ("poetry", "run", "pytest", "-m", "integration"),
-    )
+    ]
+    if not skip_version_check:
+        commands.insert(2, ("python3", "scripts/dev/validate_version.py", "--base-ref", base_ref))
+    return tuple(commands)
 
 
 def run_command(command: tuple[str, ...]) -> int:
@@ -85,7 +96,12 @@ def main() -> int:
             "Pass --base-ref or ensure refs/remotes/origin/HEAD exists."
         )
 
-    for command in build_commands(base_ref):
+    current_branch = current_branch_name()
+    skip_version_check = current_branch == base_ref
+    if skip_version_check:
+        print("Skipping version validation (base ref matches current branch).")
+
+    for command in build_commands(base_ref, skip_version_check):
         print(f"Running: {' '.join(command)}")
         exit_code = run_command(command)
         if exit_code != 0:


### PR DESCRIPTION
# Pull Request

## Summary
- Skip version validation when validating the base branch post-merge.
- Bump build version to keep version gate consistent.

## Issue Linkage
- Fixes #185

## Testing
- poetry run python3 scripts/dev/validate_local.py

## Notes
- None.
