### PR TITLE
refactor: align versioning with derived build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python 3.14
         uses: actions/setup-python@v5

--- a/docs/project/final/version-string-management.md
+++ b/docs/project/final/version-string-management.md
@@ -17,8 +17,10 @@ and notify the user.
 
 ## Local deviations
 
-- The canonical version string for MNEMOSYS Core lives in `pyproject.toml` under
-  `project.version`.
+- The base version for MNEMOSYS Core lives in `pyproject.toml` under
+  `project.version` (`MAJOR.MINOR.PATCH`).
+- `BUILD` is derived from git history at build time and is not committed to
+  source control.
 - Use the local helper scripts when available:
   - `python3 scripts/dev/submit_develop_pr.py`
   - `python3 scripts/dev/submit_release_prs.py`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "mnemosys-core"
-version = "0.1.3.10"
+version = "0.1.3"
 description = "Core backend for the MNEMOSYS system"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/scripts/dev/submit_develop_pr.py
+++ b/scripts/dev/submit_develop_pr.py
@@ -1,54 +1,30 @@
 #!/usr/bin/env python3
 """
-Prepare a pull request by enforcing version bumps and pre-submission checks.
+Prepare a pull request with pre-submission checks.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import re
 import shutil
 import subprocess
 import sys
 import tempfile
-import tomllib
-from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-VERSION_PATTERN = re.compile(
-    r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"
-)
-
 DOCUMENTATION_ONLY_FILENAMES = {"README.md", "CHANGELOG.md"}
 FORBIDDEN_BRANCHES = {"develop", "main", "release"}
-
-
-@dataclass(frozen=True)
-class Version:
-    """Semantic version with build component."""
-
-    major: int
-    minor: int
-    patch: int
-    build: int
-
-    def as_string(self) -> str:
-        """Return the version formatted as MAJOR.MINOR.PATCH.BUILD."""
-        return f"{self.major}.{self.minor}.{self.patch}.{self.build}"
 
 
 def parse_arguments(argument_list: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
-        description=(
-            "Prepare a pull request by bumping BUILD, validating, pushing, "
-            "and creating the PR."
-        )
+        description="Prepare a pull request by validating, pushing, and creating the PR."
     )
     parser.add_argument(
         "--base",
@@ -213,95 +189,6 @@ def ensure_branch_divergence(base_reference: str) -> None:
         raise SystemExit("No commits found relative to base; nothing to submit.")
 
 
-def load_version_from_toml_text(toml_text: str) -> Version:
-    """Load the version from a pyproject.toml text block."""
-    data = tomllib.loads(toml_text)
-    version_value = None
-    project_section = data.get("project")
-    if isinstance(project_section, dict):
-        version_value = project_section.get("version")
-    if version_value is None:
-        tool_section = data.get("tool")
-        poetry_section = tool_section.get("poetry") if isinstance(tool_section, dict) else None
-        if isinstance(poetry_section, dict):
-            version_value = poetry_section.get("version")
-    if version_value is None:
-        raise SystemExit(
-            "Missing version in pyproject.toml (expected project.version or tool.poetry.version)."
-        )
-    if not isinstance(version_value, str):
-        raise SystemExit("Version value in pyproject.toml must be a string.")
-    return parse_version(version_value)
-
-
-def load_current_version() -> Version:
-    """Load the version from the working tree."""
-    pyproject_text = Path("pyproject.toml").read_text()
-    return load_version_from_toml_text(pyproject_text)
-
-
-def load_base_version(base_reference: str) -> Version:
-    """Load the version from the base branch."""
-    pyproject_text = read_command_output(("git", "show", f"{base_reference}:pyproject.toml"))
-    return load_version_from_toml_text(pyproject_text)
-
-
-def parse_version(version_value: str) -> Version:
-    """Parse and validate a version string."""
-    match = VERSION_PATTERN.match(version_value)
-    if not match:
-        raise SystemExit(f"Invalid version format: {version_value}")
-    major, minor, patch, build = (int(part) for part in match.groups())
-    return Version(major=major, minor=minor, patch=patch, build=build)
-
-
-def determine_build_bump(base_version: Version, current_version: Version) -> Version | None:
-    """Return the next build version, or None if already bumped."""
-    if (base_version.major, base_version.minor, base_version.patch) != (
-        current_version.major,
-        current_version.minor,
-        current_version.patch,
-    ):
-        raise SystemExit("Major, minor, and patch must match base. Use the release workflow to change them.")
-
-    if current_version.build == base_version.build:
-        return Version(
-            major=current_version.major,
-            minor=current_version.minor,
-            patch=current_version.patch,
-            build=current_version.build + 1,
-        )
-    if current_version.build == base_version.build + 1:
-        return None
-
-    raise SystemExit("Build number must be base BUILD or base BUILD + 1.")
-
-
-def update_pyproject_version(current_version: Version, new_version: Version) -> None:
-    """Update the version string in pyproject.toml."""
-    pyproject_path = Path("pyproject.toml")
-    content = pyproject_path.read_text()
-    version_pattern = re.compile(r'^(version\s*=\s*")([^"]+)(")\s*$', re.MULTILINE)
-    matches = list(version_pattern.finditer(content))
-    if len(matches) != 1:
-        raise SystemExit("Expected a single version entry in pyproject.toml.")
-
-    match = matches[0]
-    existing_version = match.group(2)
-    if existing_version != current_version.as_string():
-        raise SystemExit("pyproject.toml version does not match expected value.")
-
-    updated = content[: match.start(2)] + new_version.as_string() + content[match.end(2) :]
-    pyproject_path.write_text(updated)
-
-
-def commit_version_bump(new_version: Version) -> None:
-    """Commit the version bump."""
-    run_command(("git", "add", "pyproject.toml"))
-    commit_message = f"chore: bump build version to {new_version.as_string()}"
-    run_command(("git", "commit", "-m", commit_message))
-
-
 def collect_changed_files(base_reference: str) -> list[str]:
     """Collect changed files relative to the base reference."""
     output = read_command_output(("git", "diff", "--name-only", f"{base_reference}...HEAD"))
@@ -315,63 +202,16 @@ def is_documentation_path(file_path: str) -> bool:
     return Path(file_path).parts[:1] == ("docs",)
 
 
-def pyproject_only_version_change(base_reference: str) -> bool:
-    """Return True if pyproject.toml changes only the version."""
-    base_text = read_command_output(("git", "show", f"{base_reference}:pyproject.toml"))
-    current_text = Path("pyproject.toml").read_text()
-    base_data = tomllib.loads(base_text)
-    current_data = tomllib.loads(current_text)
-    current_path, current_version = find_version_path(current_data)
-    base_path, _ = find_version_path(base_data)
-    if current_path != base_path:
-        return False
-    set_nested_value(base_data, base_path, current_version)
-    return base_data == current_data
-
-
-def find_version_path(toml_data: dict[str, object]) -> tuple[tuple[str, ...], str]:
-    """Return the version key path and value."""
-    project_section = toml_data.get("project")
-    if isinstance(project_section, dict):
-        project_version = project_section.get("version")
-        if isinstance(project_version, str):
-            return ("project", "version"), project_version
-    tool_section = toml_data.get("tool")
-    poetry_section = tool_section.get("poetry") if isinstance(tool_section, dict) else None
-    if isinstance(poetry_section, dict):
-        poetry_version = poetry_section.get("version")
-        if isinstance(poetry_version, str):
-            return ("tool", "poetry", "version"), poetry_version
-    raise SystemExit("Missing version in pyproject.toml (expected project.version or tool.poetry.version).")
-
-
-def set_nested_value(toml_data: dict[str, object], path: tuple[str, ...], value: str) -> None:
-    """Set a nested TOML value by path."""
-    cursor: dict[str, object] = toml_data
-    for key in path[:-1]:
-        next_value = cursor.get(key)
-        if not isinstance(next_value, dict):
-            raise SystemExit("Version path missing from pyproject.toml.")
-        cursor = next_value
-    cursor[path[-1]] = value
-
-
-def determine_documentation_only(changed_files: list[str], base_reference: str) -> bool:
-    """Return True if changes are documentation-only plus a version bump."""
-    remaining_files = [path for path in changed_files if path != "pyproject.toml"]
-    if not all(is_documentation_path(path) for path in remaining_files):
-        return False
-    return not (
-        "pyproject.toml" in changed_files and not pyproject_only_version_change(base_reference)
-    )
+def determine_documentation_only(changed_files: list[str]) -> bool:
+    """Return True if changes are documentation-only."""
+    return bool(changed_files) and all(is_documentation_path(path) for path in changed_files)
 
 
 def build_default_title(base_reference: str, current_branch: str) -> str:
     """Derive a default pull request title."""
     commit_messages = read_command_output(("git", "log", "--format=%s", f"{base_reference}..HEAD"))
     for message in commit_messages.splitlines():
-        if not message.startswith("chore: bump build version to"):
-            return message
+        return message
     return current_branch.replace("-", " ")
 
 
@@ -465,15 +305,8 @@ def main(argument_list: Sequence[str] | None = None) -> int:
     ensure_branch_allowed(current_branch, arguments.base)
     ensure_branch_divergence(base_reference)
 
-    base_version = load_base_version(base_reference)
-    current_version = load_current_version()
-    new_version = determine_build_bump(base_version, current_version)
-    if new_version is not None:
-        update_pyproject_version(current_version, new_version)
-        commit_version_bump(new_version)
-
     changed_files = collect_changed_files(base_reference)
-    documentation_only = determine_documentation_only(changed_files, base_reference)
+    documentation_only = determine_documentation_only(changed_files)
     if not documentation_only or arguments.force_validation:
         run_validation(arguments.base)
 

--- a/scripts/dev/submit_release_prs.py
+++ b/scripts/dev/submit_release_prs.py
@@ -20,23 +20,20 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-VERSION_PATTERN = re.compile(
-    r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"
-)
+VERSION_PATTERN = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
 
 
 @dataclass(frozen=True)
 class Version:
-    """Semantic version with build component."""
+    """Semantic version without a build component."""
 
     major: int
     minor: int
     patch: int
-    build: int
 
     def as_string(self) -> str:
-        """Return the version formatted as MAJOR.MINOR.PATCH.BUILD."""
-        return f"{self.major}.{self.minor}.{self.patch}.{self.build}"
+        """Return the version formatted as MAJOR.MINOR.PATCH."""
+        return f"{self.major}.{self.minor}.{self.patch}"
 
     def as_branch_label(self) -> str:
         """Return the version formatted for use in branch names."""
@@ -48,7 +45,7 @@ def parse_arguments(argument_list: Sequence[str] | None = None) -> argparse.Name
     parser = argparse.ArgumentParser(
         description=(
             "Create a develop->release PR via a promotion branch and a patch-bump PR to develop. "
-            "The patch bump increments PATCH and resets BUILD to 0."
+            "The patch bump increments PATCH."
         )
     )
     parser.add_argument(
@@ -226,8 +223,8 @@ def parse_version(version_value: str) -> Version:
     match = VERSION_PATTERN.match(version_value)
     if not match:
         raise SystemExit(f"Invalid version format: {version_value}")
-    major, minor, patch, build = (int(part) for part in match.groups())
-    return Version(major=major, minor=minor, patch=patch, build=build)
+    major, minor, patch = (int(part) for part in match.groups())
+    return Version(major=major, minor=minor, patch=patch)
 
 
 def load_version_from_toml_text(toml_text: str) -> Version:
@@ -258,12 +255,11 @@ def load_develop_version(develop_branch: str) -> Version:
 
 
 def bump_patch_version(version: Version) -> Version:
-    """Return the next patch version with build reset."""
+    """Return the next patch version."""
     return Version(
         major=version.major,
         minor=version.minor,
         patch=version.patch + 1,
-        build=0,
     )
 
 

--- a/scripts/dev/validate_local.py
+++ b/scripts/dev/validate_local.py
@@ -33,15 +33,6 @@ def read_command_output(command: tuple[str, ...]) -> str:
     return result.stdout.strip()
 
 
-def current_branch_name() -> str | None:
-    """Return the current branch name, or None if detached."""
-    try:
-        reference = read_command_output(("git", "symbolic-ref", "--quiet", "HEAD"))
-    except subprocess.CalledProcessError:
-        return None
-    return reference.rsplit("/", maxsplit=1)[-1] if reference else None
-
-
 def resolve_default_base_ref() -> str | None:
     """Resolve the default base ref from origin/HEAD."""
     try:
@@ -51,11 +42,12 @@ def resolve_default_base_ref() -> str | None:
     return reference.rsplit("/", maxsplit=1)[-1] if reference else None
 
 
-def build_commands(base_ref: str, skip_version_check: bool) -> tuple[tuple[str, ...], ...]:
+def build_commands(base_ref: str) -> tuple[tuple[str, ...], ...]:
     """Build validation commands matching CI hard gates."""
     commands: list[tuple[str, ...]] = [
         ("python3", "scripts/dev/validate_venv.py"),
         ("python3", "scripts/dev/validate_dependency_specs.py"),
+        ("python3", "scripts/dev/validate_version.py", "--base-ref", base_ref),
         ("poetry", "check", "--lock"),
         ("poetry", "sync", "--dry-run"),
         ("poetry", "run", "pip-audit", "-r", "requirements.txt", "-r", "requirements-dev.txt"),
@@ -75,8 +67,6 @@ def build_commands(base_ref: str, skip_version_check: bool) -> tuple[tuple[str, 
         ),
         ("poetry", "run", "pytest", "-m", "integration"),
     ]
-    if not skip_version_check:
-        commands.insert(2, ("python3", "scripts/dev/validate_version.py", "--base-ref", base_ref))
     return tuple(commands)
 
 
@@ -96,12 +86,7 @@ def main() -> int:
             "Pass --base-ref or ensure refs/remotes/origin/HEAD exists."
         )
 
-    current_branch = current_branch_name()
-    skip_version_check = current_branch == base_ref
-    if skip_version_check:
-        print("Skipping version validation (base ref matches current branch).")
-
-    for command in build_commands(base_ref, skip_version_check):
+    for command in build_commands(base_ref):
         print(f"Running: {' '.join(command)}")
         exit_code = run_command(command)
         if exit_code != 0:

--- a/scripts/dev/validate_version.py
+++ b/scripts/dev/validate_version.py
@@ -17,27 +17,27 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-VERSION_PATTERN = re.compile(
-    r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"
+VERSION_PATTERN = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+VERSION_WITH_BUILD_PATTERN = re.compile(
+    r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:\.(0|[1-9][0-9]*))?$"
 )
 
 
 @dataclass(frozen=True)
 class Version:
-    """Semantic version with build component."""
+    """Semantic version without a build component."""
 
     major: int
     minor: int
     patch: int
-    build: int
 
     def as_string(self) -> str:
-        """Return the version formatted as MAJOR.MINOR.PATCH.BUILD."""
-        return f"{self.major}.{self.minor}.{self.patch}.{self.build}"
+        """Return the version formatted as MAJOR.MINOR.PATCH."""
+        return f"{self.major}.{self.minor}.{self.patch}"
 
-    def as_tuple(self) -> tuple[int, int, int, int]:
+    def as_tuple(self) -> tuple[int, int, int]:
         """Return the version as a comparison tuple."""
-        return (self.major, self.minor, self.patch, self.build)
+        return (self.major, self.minor, self.patch)
 
 
 def parse_arguments(argument_list: Sequence[str] | None = None) -> argparse.Namespace:
@@ -88,16 +88,17 @@ def resolve_base_reference(base_reference: str) -> str:
     )
 
 
-def parse_version(version_value: str) -> Version:
+def parse_version(version_value: str, allow_build: bool) -> Version:
     """Parse and validate a version string."""
-    match = VERSION_PATTERN.match(version_value)
+    pattern = VERSION_WITH_BUILD_PATTERN if allow_build else VERSION_PATTERN
+    match = pattern.match(version_value)
     if not match:
         raise SystemExit(f"Invalid version format: {version_value}")
-    major, minor, patch, build = (int(match.group(index)) for index in range(1, 5))
-    return Version(major=major, minor=minor, patch=patch, build=build)
+    major, minor, patch = (int(match.group(index)) for index in range(1, 4))
+    return Version(major=major, minor=minor, patch=patch)
 
 
-def load_version_from_toml_text(toml_text: str) -> Version:
+def load_version_from_toml_text(toml_text: str, allow_build: bool) -> Version:
     """Load the version from a pyproject.toml text block."""
     data = tomllib.loads(toml_text)
     version_value = None
@@ -115,59 +116,97 @@ def load_version_from_toml_text(toml_text: str) -> Version:
         )
     if not isinstance(version_value, str):
         raise SystemExit("Version value in pyproject.toml must be a string.")
-    return parse_version(version_value)
+    return parse_version(version_value, allow_build)
 
 
 def load_version_from_worktree() -> Version:
     """Load the version from the working tree."""
     pyproject_text = Path("pyproject.toml").read_text(encoding="utf-8")
-    return load_version_from_toml_text(pyproject_text)
+    return load_version_from_toml_text(pyproject_text, allow_build=False)
 
 
 def load_version_from_git(reference: str) -> Version:
     """Load the version from a git reference."""
     pyproject_text = read_command_output(("git", "show", f"{reference}:pyproject.toml"))
-    return load_version_from_toml_text(pyproject_text)
+    return load_version_from_toml_text(pyproject_text, allow_build=True)
 
 
-def ensure_version_is_greater(base_version: Version, head_version: Version, base_reference: str) -> None:
-    """Ensure the head version is greater than the base."""
-    if head_version.as_tuple() <= base_version.as_tuple():
+def find_base_version_commit(version: Version) -> str:
+    """Return the commit that introduced the base version."""
+    version_literal = f'version = "{version.as_string()}"'
+    output = read_command_output(
+        ("git", "log", "--format=%H", "-S", version_literal, "--", "pyproject.toml")
+    )
+    commits = [line for line in output.splitlines() if line]
+    if not commits:
         raise SystemExit(
-            "Version must advance relative to the base branch. "
-            f"Base ({base_reference}) is {base_version.as_string()}, "
-            f"head is {head_version.as_string()}."
+            "Unable to locate base version commit in history. "
+            "Ensure full git history is available."
+        )
+
+    for commit in commits:
+        try:
+            pyproject_text = read_command_output(("git", "show", f"{commit}:pyproject.toml"))
+        except subprocess.CalledProcessError:
+            continue
+        if load_version_from_toml_text(pyproject_text, allow_build=False).as_tuple() == version.as_tuple():
+            return commit
+
+    raise SystemExit(
+        "Unable to verify base version commit in history. "
+        "Ensure full git history is available."
+    )
+
+
+def derive_build_number(version: Version) -> int:
+    """Derive the build number from git history."""
+    base_commit = find_base_version_commit(version)
+    count_text = read_command_output(("git", "rev-list", "--count", f"{base_commit}..HEAD"))
+    try:
+        return int(count_text)
+    except ValueError as exc:
+        raise SystemExit("Derived build number is not numeric.") from exc
+
+
+def ensure_version_not_regressed(base_version: Version, head_version: Version) -> None:
+    """Ensure the head version does not regress from the base."""
+    if head_version.as_tuple() < base_version.as_tuple():
+        raise SystemExit(
+            "Base version regressed. "
+            f"Base is {base_version.as_string()}, head is {head_version.as_string()}."
         )
 
 
 def validate_develop_rules(base_version: Version, head_version: Version) -> None:
     """Validate develop-bound version rules."""
-    if (head_version.major, head_version.minor, head_version.patch) == (
-        base_version.major,
-        base_version.minor,
-        base_version.patch,
-    ):
-        expected_build = base_version.build + 1
-        if head_version.build != expected_build:
-            raise SystemExit(
-                "BUILD must increment by exactly 1 for develop PRs. "
-                f"Expected {expected_build}, got {head_version.build}."
-            )
-        return
-
     if (head_version.major, head_version.minor) == (base_version.major, base_version.minor):
-        expected_patch = base_version.patch + 1
-        if head_version.patch != expected_patch:
-            raise SystemExit(
-                "PATCH must increment by exactly 1 when MAJOR/MINOR are unchanged. "
-                f"Expected {expected_patch}, got {head_version.patch}."
-            )
-        if head_version.build != 0:
-            raise SystemExit("BUILD must reset to 0 when PATCH increments.")
+        if head_version.patch == base_version.patch:
+            return
+        if head_version.patch == base_version.patch + 1:
+            return
+        raise SystemExit(
+            "PATCH must remain the same for feature work or increment by 1 for a new cycle. "
+            f"Base is {base_version.as_string()}, head is {head_version.as_string()}."
+        )
+
+    if head_version.major == base_version.major and head_version.minor > base_version.minor:
+        if head_version.patch != 0:
+            raise SystemExit("PATCH must reset to 0 when MINOR changes.")
         return
 
-    if head_version.patch != 0 or head_version.build != 0:
-        raise SystemExit("PATCH and BUILD must reset to 0 when MAJOR or MINOR changes.")
+    if head_version.major > base_version.major:
+        if head_version.minor != 0 or head_version.patch != 0:
+            raise SystemExit("MINOR and PATCH must reset to 0 when MAJOR changes.")
+        return
+
+
+def validate_promotion_rules(base_branch: str, base_version: Version, head_version: Version) -> None:
+    """Validate promotion-bound version rules."""
+    if base_branch in {"release", "main"} and head_version.as_tuple() != base_version.as_tuple():
+        raise SystemExit(
+            "Promotion pull requests must not change the base version. "
+            f"Base is {base_version.as_string()}, head is {head_version.as_string()}."
+        )
 
 
 def main() -> int:
@@ -175,17 +214,20 @@ def main() -> int:
     ensure_project_root()
 
     head_version = load_version_from_worktree()
+    derive_build_number(head_version)
 
     base_reference = arguments.base_ref or os.environ.get("GITHUB_BASE_REF")
     event_name = arguments.event_name or os.environ.get("GITHUB_EVENT_NAME", "")
     if base_reference and (event_name == "pull_request" or arguments.base_ref is not None):
         resolved_base = resolve_base_reference(base_reference)
         base_version = load_version_from_git(resolved_base)
-        ensure_version_is_greater(base_version, head_version, resolved_base)
+        ensure_version_not_regressed(base_version, head_version)
 
         base_branch = resolved_base.split("/")[-1]
         if base_branch == "develop":
             validate_develop_rules(base_version, head_version)
+        else:
+            validate_promotion_rules(base_branch, base_version, head_version)
     return 0
 
 

--- a/src/mnemosys_core/api/app.py
+++ b/src/mnemosys_core/api/app.py
@@ -4,6 +4,7 @@ FastAPI application factory.
 
 from __future__ import annotations
 
+from importlib import metadata
 from typing import TYPE_CHECKING
 
 from fastapi import FastAPI
@@ -32,7 +33,7 @@ def create_app(engine: Engine) -> FastAPI:
     app = FastAPI(
         title="Mnemosys Core API",
         description="MNEMOSYS practice tracking API",
-        version="0.1.0",
+        version=metadata.version("mnemosys-core"),
     )
 
     # Configure dependency injection


### PR DESCRIPTION
# Pull Request

## Summary
- Align application versioning to derive BUILD from git history.
- Update validation and helper scripts to use base version only.
- Remove hardcoded API version and use package metadata.

## Issue Linkage
- Fixes #187

## Testing
- poetry run python3 scripts/dev/validate_local.py

## Notes
- None.
