### PR TITLE
fix: install package metadata in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,11 @@ RUN pip install --no-cache-dir -r /app/requirements.txt
 
 COPY alembic /app/alembic
 COPY alembic.ini /app/alembic.ini
+COPY pyproject.toml /app/pyproject.toml
+COPY README.md /app/README.md
+COPY LICENSE /app/LICENSE
 COPY src /app/src
+RUN pip install --no-cache-dir --no-deps /app
 COPY scripts/runtime/entrypoint.sh /app/scripts/runtime/entrypoint.sh
 
 RUN chmod +x /app/scripts/runtime/entrypoint.sh


### PR DESCRIPTION
# Pull Request

## Summary
- Install the `mnemosys-core` package into the container image so `importlib.metadata` can resolve the version at runtime.

## Issue Linkage
- Fixes #201

## Testing
- `.venv/bin/python3 -m pytest tests/`
- `.venv/bin/python3 scripts/dev/validate_local.py --base-ref develop`

## Notes
- This addresses the ECS crash from `PackageNotFoundError` by adding a package install step to the Docker image.
