### PR TITLE
chore: standardize python invocations on uv run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,7 @@ Before pushing the branch or submitting a PR, you MUST run and pass the full loc
 
 ```bash
 # Run local validation (mirrors CI hard gates)
-python3 scripts/dev/validate_local.py
+uv run python3 scripts/dev/validate_local.py
 ```
 
 **All checks must pass with:**
@@ -238,7 +238,7 @@ Finalize PR?
 **What "Finalize" means** (unless user specifies otherwise):
 1. Merge PR with squash merge and delete remote branch
 2. Update local develop branch (checkout and pull)
-3. Verify .venv is in sync with dependency specification (uv sync --check --frozen --group dev)
+3. Verify the uv environment is in sync (uv sync --check --frozen --group dev)
 4. Run final validation (tests, coverage, quality checks)
 5. Ready for next iteration of changes
 
@@ -257,7 +257,7 @@ Finalize PR?
 4. ⏸️ **PAUSE #1** - Ask: "Submit PR?" (unless Finalize Override is active)
 5. If approved: Push branch and submit PR
 6. ⏸️ **PAUSE #2** - Ask: "Finalize PR?" (unless Finalize Override is active)
-7. If approved: Execute finalization (merge, update develop, verify .venv, validate)
+7. If approved: Execute finalization (merge, update develop, verify uv environment, validate)
 8. If not approved: Wait for user to review/request changes
 
 ## Project Structure
@@ -310,12 +310,11 @@ Currently minimal - avoid adding heavy dependencies without justification.
 git clone <repository-url>
 cd mnemosys-core
 
-# Create and activate virtual environment (recommended)
-python3 -m venv .venv
-source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+# Install uv if missing
+python3 -m pip install uv==0.9.26
 
 # Install dependencies
-python3 -m pip install -e .
+uv sync --group dev
 ```
 
 ### Database Bootstrapping
@@ -323,21 +322,21 @@ python3 -m pip install -e .
 For local development:
 
 ```bash
-python3 scripts/dev/bootstrap_db.py
+uv run python3 scripts/dev/bootstrap_db.py
 ```
 
 ### Running Tests
 
 ```bash
 # Run all tests
-pytest tests/
+uv run pytest tests/
 
 # Run specific test directory
-pytest tests/db/
-pytest tests/util/
+uv run pytest tests/db/
+uv run pytest tests/util/
 
 # Run with coverage (if configured)
-pytest --cov=mnemosys_core tests/
+uv run pytest --cov=mnemosys_core tests/
 ```
 
 ## Coding Conventions

--- a/README.md
+++ b/README.md
@@ -22,39 +22,34 @@ are created explicitly.
 Requires Python 3.14+.
 
 ```bash
-python3 -m venv .venv
-source .venv/bin/activate
-python3 -m pip install -e .
+python3 -m pip install uv==0.9.26
+uv sync --group dev
 ```
 
-Use the virtual environment for all Python invocations and always call
-`python3` (never `python`). On macOS, `python` may not exist outside the venv.
+Use the uv-managed environment for all Python invocations and always call
+`uv run python3` (never `python`). On macOS, `python` may not exist outside the venv.
 
 ## Development
 
 Before starting any new development effort, run the unit tests and confirm they
 pass. This avoids inheriting broken local artifacts from prior work.
 
-All commands below assume the `.venv` is active. Always use `python3` for
-Python invocations.
+All commands below use `uv run python3` to ensure the uv environment is active.
 
 ```bash
-pytest tests/
+uv run pytest tests/
 ```
 
 ```bash
 # Full local validation (tests, coverage, lint, type check)
-python3 scripts/dev/validate_local.py
+uv run python3 scripts/dev/validate_local.py
 
 # Run tests only
-pytest tests/
+uv run pytest tests/
 
 # Bootstrap a local database (if needed)
-python3 scripts/dev/bootstrap_db.py
+uv run python3 scripts/dev/bootstrap_db.py
 ```
-
-Note: the validation script uses Poetry under the hood; install Poetry if
-you plan to run the full local checks.
 
 ## Where the Rules Live
 

--- a/docs/operations/2026-01-13-13-33-end-to-end-validation.md
+++ b/docs/operations/2026-01-13-13-33-end-to-end-validation.md
@@ -23,7 +23,7 @@
   - `docker stop mnemosys-migrations-postgres`
   Output: migration validation succeeded (no output).
 - Ran full local validation.
-  Command: `python3 scripts/dev/validate_local.py`
+  Command: `uv run python3 scripts/dev/validate_local.py`
   Output: `All checks passed`, `184 passed in 23.74s`, coverage 100%.
 
 ## Outcomes and Status

--- a/docs/operations/2026-01-21-15-25-uv-migration.md
+++ b/docs/operations/2026-01-21-15-25-uv-migration.md
@@ -18,29 +18,29 @@ to uv.
 ## Commands executed
 ```
 # Inspect uv version availability
-source .venv/bin/activate && python3 -m pip index versions uv | head -n 1
+python3 -m pip index versions uv | head -n 1
 
-# Install pinned uv version in the project venv
-source .venv/bin/activate && python3 -m pip install uv==0.9.26
+# Install pinned uv version
+python3 -m pip install uv==0.9.26
 
 # Verify uv CLI options
-source .venv/bin/activate && uv --help
-source .venv/bin/activate && uv help lock
-source .venv/bin/activate && uv help sync
-source .venv/bin/activate && uv help export
+uv --help
+uv help lock
+uv help sync
+uv help export
 
 # Validate uv can lock with existing metadata
-source .venv/bin/activate && uv lock --dry-run
+uv lock --dry-run
 
 # Generate uv.lock with the updated pyproject.toml
-source .venv/bin/activate && uv lock
+uv lock
 
 # Export requirements files from uv.lock
-source .venv/bin/activate && uv export --frozen --format requirements.txt --output-file requirements.txt --no-hashes --no-emit-project
-source .venv/bin/activate && uv export --frozen --format requirements.txt --output-file requirements-dev.txt --no-hashes --group dev --no-emit-project
+uv export --frozen --format requirements.txt --output-file requirements.txt --no-hashes --no-emit-project
+uv export --frozen --format requirements.txt --output-file requirements-dev.txt --no-hashes --group dev --no-emit-project
 
 # Sync the local environment with the new lockfile
-source .venv/bin/activate && uv sync --frozen --group dev
+uv sync --frozen --group dev
 
 # Remove the legacy lockfile
 rm <legacy-lockfile>

--- a/docs/plans/complete/2025-12-31-github-actions-ci-design.md
+++ b/docs/plans/complete/2025-12-31-github-actions-ci-design.md
@@ -61,7 +61,7 @@ on:
 - `integration-tests` (migration + Postgres fidelity)
   - Runs on: `ubuntu-latest`
   - Python 3.14 only
-  - Executes `pytest -m integration` (Testcontainers; Docker required)
+  - Executes `uv run pytest -m integration` (Testcontainers; Docker required)
 
 ## Python Version Strategy
 

--- a/docs/plans/in-progress/2026-01-03-alembic-schema-management-design.md
+++ b/docs/plans/in-progress/2026-01-03-alembic-schema-management-design.md
@@ -240,16 +240,16 @@ ALTER DEFAULT PRIVILEGES FOR ROLE mnemosys_sandbox_admin IN SCHEMA mnemosys
 1. Update SQLAlchemy models.
 2. Generate a revision:
    ```bash
-   python3 scripts/dev/alembic_revision.py short_snake_case_message
+   uv run python3 scripts/dev/alembic_revision.py short_snake_case_message
    ```
 3. Review the revision and edit by hand if needed.
 4. Run automated migration validation (temp schema upgrade/downgrade):
    ```bash
-   python3 scripts/dev/validate_migrations.py
+   uv run python3 scripts/dev/validate_migrations.py
    ```
    Optional seed script:
    ```bash
-   python3 scripts/dev/validate_migrations.py --seed-script <path-to-seed-script>
+   uv run python3 scripts/dev/validate_migrations.py --seed-script <path-to-seed-script>
    ```
 5. Commit the revision file and model changes.
 
@@ -269,7 +269,7 @@ Implemented validation steps (local and CI):
 - Integration tests spin up Postgres via Testcontainers.
 - `scripts/dev/validate_migrations.py` creates a temporary schema, runs upgrade and downgrade, and cleans up.
 - Optional seed scripts can populate minimal data before validation.
-- CI runs `pytest -m integration` in a dedicated job to enforce migration safety.
+- CI runs `uv run pytest -m integration` in a dedicated job to enforce migration safety.
 
 ## Observability and Audit
 
@@ -378,7 +378,7 @@ Phase 5: Operational integration (pending)
 - Add observability hooks (logs/metrics) for migration steps.
 
 Phase 6: End-to-end validation (pending)
-- Run full local validation (`python3 scripts/dev/validate_local.py`) with migration checks included.
+- Run full local validation (`uv run python3 scripts/dev/validate_local.py`) with migration checks included.
 - Dry-run the deployment sequence in a non-production environment.
 
 ## Open Questions

--- a/docs/plans/pending/2026-01-06-alembic-release-squash-and-extraction-plan.md
+++ b/docs/plans/pending/2026-01-06-alembic-release-squash-and-extraction-plan.md
@@ -49,9 +49,9 @@ This plan extends `docs/plans/in-progress/2026-01-03-alembic-schema-management-d
 ## End-to-End Pipeline Validation
 
 1. Create a reversible dummy model change and generate a revision via
-   `python3 scripts/dev/alembic_revision.py <short_snake_case>`.
+   `uv run python3 scripts/dev/alembic_revision.py <short_snake_case>`.
 2. Validate locally in the sandbox only:
-   `python3 scripts/dev/validate_migrations.py`.
+   `uv run python3 scripts/dev/validate_migrations.py`.
 3. Open PR to `develop` and merge.
    - GitHub Actions deploys to development.
    - Migration gate runs via pipeline (no manual migration).

--- a/docs/project/final/version-string-management.md
+++ b/docs/project/final/version-string-management.md
@@ -22,6 +22,6 @@ and notify the user.
 - `BUILD` is derived from git history at build time and is not committed to
   source control.
 - Use the local helper scripts when available:
-  - `python3 scripts/dev/submit_develop_pr.py`
-  - `python3 scripts/dev/submit_release_prs.py`
-  - `python3 scripts/dev/submit_main_pr.py`
+  - `uv run python3 scripts/dev/submit_develop_pr.py`
+  - `uv run python3 scripts/dev/submit_release_prs.py`
+  - `uv run python3 scripts/dev/submit_main_pr.py`

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -95,17 +95,17 @@ standards.
 Before starting any new development effort, run the unit tests and confirm they
 pass. This guards against inheriting broken local artifacts from prior work.
 
-All Python commands must run inside the project venv (use `uv run ...` or the
-`.venv/bin/python3` interpreter). Do not rely on a system `python` binary; use
-`python3` for all Python invocations.
+All Python commands must run inside the uv environment. Use
+`uv run python3 ...` for every Python invocation and do not rely on a system
+`python` binary.
 
 Enable repository git hooks before committing:
 - `git config core.hooksPath scripts/git-hooks`
 
 Use one of:
-- `pytest tests/`
-- `python3 scripts/dev/validate_local.py`
-- Docs-only changes: `python3 scripts/dev/validate_docs.py`
+- `uv run pytest tests/`
+- `uv run python3 scripts/dev/validate_local.py`
+- Docs-only changes: `uv run python3 scripts/dev/validate_docs.py`
 
 Docs-only validation requires `markdownlint` `0.41.0` or newer on the PATH. If
 it is not available, `npx` must be installed so the validation script can run

--- a/scripts/dev/validate_local.py
+++ b/scripts/dev/validate_local.py
@@ -45,9 +45,9 @@ def resolve_default_base_ref() -> str | None:
 def build_commands(base_ref: str) -> tuple[tuple[str, ...], ...]:
     """Build validation commands matching CI hard gates."""
     commands: list[tuple[str, ...]] = [
-        ("python3", "scripts/dev/validate_venv.py"),
-        ("python3", "scripts/dev/validate_dependency_specs.py"),
-        ("python3", "scripts/dev/validate_version.py", "--base-ref", base_ref),
+        ("uv", "run", "python3", "scripts/dev/validate_venv.py"),
+        ("uv", "run", "python3", "scripts/dev/validate_dependency_specs.py"),
+        ("uv", "run", "python3", "scripts/dev/validate_version.py", "--base-ref", base_ref),
         ("bash", "scripts/lint/repo-profile.sh"),
         ("bash", "scripts/lint/markdown-standards.sh"),
         ("bash", "scripts/lint/commit-messages.sh", base_ref, "HEAD"),

--- a/scripts/dev/validate_venv.py
+++ b/scripts/dev/validate_venv.py
@@ -90,7 +90,7 @@ def validate_venv() -> None:
     validate_uv_version()
     venv_path = Path(".venv").resolve()
     if not venv_path.is_dir():
-        raise SystemExit("Missing .venv. Rebuild with: python3 -m venv .venv")
+        raise SystemExit("Missing .venv. Rebuild with: uv sync --group dev")
 
     python_path = venv_path / "bin" / "python3"
     if not python_path.exists():


### PR DESCRIPTION
## Summary
- Standardize docs and validation scripts on `uv run python3`/`uv run pytest`.
- Align repo instructions with uv-managed environments.
- Update legacy ops/plan docs to remove direct venv activation and python3 usage.

## Issue Linkage
- Fixes #204

## Testing
- `uv run python3 scripts/dev/validate_local.py`
