### PR TITLE
chore: remove stale include directive and add standards reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # MNEMOSYS Core
 
-<!-- include: standards-and-conventions.md -->
+**Standards reference**: <https://github.com/wphillipmoore/standards-and-conventions>
+— active standards documentation lives in the standard-tooling repository under `docs/`.
+Repository profile: `standard-tooling.toml`.
 
 ## User Overrides (Optional)
 

--- a/standard-tooling.toml
+++ b/standard-tooling.toml
@@ -1,0 +1,13 @@
+[project]
+repository-type = "application"
+versioning-scheme = "application"
+branching-model = "application-promotion"
+release-model = "environment-promotion"
+primary-language = "python"
+
+[project.co-authors]
+claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
+codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
+
+[dependencies]
+standard-tooling = "v1.4"


### PR DESCRIPTION
# Pull Request

## Summary

- Remove the stale include directive from AGENTS.md and replace it with a standards reference directive. Also add standard-tooling.toml for st-commit co-author resolution.

## Issue Linkage

- Ref #438 (wphillipmoore/standard-tooling#438 — cross-repo sweep)

## Testing

- Docs/config-only change; no code changes.

## Notes

- The `dependency-audit` failure is pre-existing (known CVEs in pip, pygments, pytest, python-dotenv, requests) and unrelated to this change.
