### PR TITLE
chore: seed standard-tooling.toml and strip config sections

### DIFF
--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -9,6 +9,7 @@ Standards and Conventions repository should be treated as in-progress standards
 unless explicitly documented here as conventions.
 
 ## Table of Contents
+
 - [Access requirements](#access-requirements)
 - [Project terminology](#project-terminology)
   - [Official project name](#official-project-name)
@@ -16,11 +17,10 @@ unless explicitly documented here as conventions.
   - [Name rationale](#name-rationale)
   - [Usage in historical documents](#usage-in-historical-documents)
   - [CI gates](#ci-gates)
-- [Repository profile](#repository-profile)
 - [Local development preflight](#local-development-preflight)
-- [AI co-author identities](#ai-co-author-identities)
 
 ## Access requirements
+
 When reading canonical standards, use the raw GitHub content endpoint for
 deterministic access:
 `https://raw.githubusercontent.com/wphillipmoore/standards-and-conventions/develop/<path>`
@@ -32,16 +32,19 @@ proceed with assumptions or alternate sources.
 ## Project terminology
 
 ### Official project name
+
 **MNEMOSYS** (pronounced /ˈniːməˌsɪs/, or "NEE-muh-sis")
 
 This is the canonical name for the project and must be used consistently across
 all:
+
 - Code (comments, docstrings, API descriptions)
 - Documentation (design docs, user guides, README files)
 - Repository metadata (package names, project descriptions)
 - External communications
 
 ### Deprecated names
+
 The following names are deprecated and should not be used in new code or
 documentation:
 
@@ -51,6 +54,7 @@ documentation:
   extension, now integrated as core MNEMOSYS functionality
 
 ### Name rationale
+
 From the Greek root "mneme" meaning "memory, remembrance."
 
 The name reflects the system's core thesis: skills are memory structures with
@@ -61,37 +65,33 @@ See `docs/project/final/Philosophy.md` for the complete philosophical
 foundation.
 
 ### Usage in historical documents
+
 Early design documents (v0.1 snapshots) may reference deprecated names in their
 original context. When updating these documents, add a nomenclature note
 explaining the name evolution while preserving the historical snapshot.
 
 ### CI gates
+
 CI gate definitions follow the canonical standards.
 
 Hard gates (all are required status checks):
+
 - `test-and-validate (3.14)`
 - `integration-tests`
 - `dependency-audit`
 
 Soft gates:
+
 - None.
 
 Branch applicability:
+
 - develop: all hard gates required
 - release: all hard gates required
 - main: all hard gates required
 
-## Repository profile
-These entries supply project-specific values required by the canonical
-standards.
-
-- repository_type: application
-- versioning_scheme: application
-- branching_model: application-promotion
-- release_model: environment-promotion
-- supported_release_lines: single
-
 ## Local development preflight
+
 Before starting any new development effort, run the unit tests and confirm they
 pass. This guards against inheriting broken local artifacts from prior work.
 
@@ -100,9 +100,11 @@ All Python commands must run inside the uv environment. Use
 `python` binary.
 
 Enable repository git hooks before committing:
+
 - `git config core.hooksPath scripts/git-hooks`
 
 Use one of:
+
 - `uv run pytest tests/`
 - `uv run python3 scripts/dev/validate_local.py`
 - Docs-only changes: `uv run python3 scripts/dev/validate_docs.py`
@@ -112,12 +114,5 @@ it is not available, `npx` must be installed so the validation script can run
 the minimum supported version.
 
 Tooling requirement:
+
 - `uv` `0.9.26` (install with `python3 -m pip install uv==0.9.26`).
-
-## AI co-author identities
-Approved AI co-author trailers for this repository:
-
-```
-Co-Authored-By: mnemosys-codex <252598091+mnemosys-codex@users.noreply.github.com>
-Co-Authored-By: mnemosys-claude <252602472+mnemosys-claude@users.noreply.github.com>
-```

--- a/scripts/lint/repo-profile.sh
+++ b/scripts/lint/repo-profile.sh
@@ -1,45 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-profile_file="docs/repository-standards.md"
+profile_file="standard-tooling.toml"
 
 if [[ ! -f "$profile_file" ]]; then
-  echo "ERROR: repository profile file not found at $profile_file" >&2
+  echo "ERROR: $profile_file not found" >&2
   exit 2
 fi
 
-repository_type=""
-versioning_scheme=""
-branching_model=""
-release_model=""
-supported_release_lines=""
-
-while IFS= read -r line; do
-  if [[ "$line" =~ ^[[:space:]-]*repository_type:[[:space:]]*(.+)$ ]]; then
-    repository_type="${BASH_REMATCH[1]}"
-  elif [[ "$line" =~ ^[[:space:]-]*versioning_scheme:[[:space:]]*(.+)$ ]]; then
-    versioning_scheme="${BASH_REMATCH[1]}"
-  elif [[ "$line" =~ ^[[:space:]-]*branching_model:[[:space:]]*(.+)$ ]]; then
-    branching_model="${BASH_REMATCH[1]}"
-  elif [[ "$line" =~ ^[[:space:]-]*release_model:[[:space:]]*(.+)$ ]]; then
-    release_model="${BASH_REMATCH[1]}"
-  elif [[ "$line" =~ ^[[:space:]-]*supported_release_lines:[[:space:]]*(.+)$ ]]; then
-    supported_release_lines="${BASH_REMATCH[1]}"
-  fi
-done < "$profile_file"
-
 failed=0
 
-for key in repository_type versioning_scheme branching_model release_model supported_release_lines; do
-  value="${!key}"
+for key in repository-type versioning-scheme branching-model release-model primary-language; do
+  value=$(grep -E "^${key}[[:space:]]*=" "$profile_file" | head -1 | sed 's/^[^=]*=[[:space:]]*//' | tr -d '"' || true)
   if [[ -z "$value" ]]; then
-    echo "ERROR: repository profile missing required attribute '$key' in $profile_file" >&2
-    failed=1
-    continue
-  fi
-
-  if [[ "$value" == *"<"* || "$value" == *">"* || "$value" == *"|"* ]]; then
-    echo "ERROR: repository profile attribute '$key' appears to be a placeholder: $value" >&2
+    echo "ERROR: missing required field '$key' in $profile_file" >&2
     failed=1
   fi
 done

--- a/standard-tooling.toml
+++ b/standard-tooling.toml
@@ -1,0 +1,13 @@
+[project]
+repository-type = "application"
+versioning-scheme = "application"
+branching-model = "application-promotion"
+release-model = "environment-promotion"
+primary-language = "none"
+
+[project.co-authors]
+claude = "Co-Authored-By: mnemosys-claude <252602472+mnemosys-claude@users.noreply.github.com>"
+codex = "Co-Authored-By: mnemosys-codex <252598091+mnemosys-codex@users.noreply.github.com>"
+
+[dependencies]
+standard-tooling = "v1.4"


### PR DESCRIPTION
# Pull Request

## Summary

- Seed standard-tooling.toml and strip config sections from repository-standards.md

## Issue Linkage

- Ref #363

## Testing

- `python3 scripts/dev/validate_local.py`
- Docs-only: `python3 scripts/dev/validate_docs.py`

## Notes

- Part of the standard-tooling.toml migration (wphillipmoore/standard-tooling#363 Phase 1+3).